### PR TITLE
Allow incorrect UTF-8 output

### DIFF
--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -293,7 +293,8 @@ where
         {
             if num_tokens[index] > 0 {
                 let token = sample(probs.to_vec(), 0.5);
-                let word = String::from_utf8(tokenizer.decode(&[token])?)?;
+                let decoded = tokenizer.decode(&[token])?;
+                let word = String::from_utf8_lossy(&decoded);
                 tokens[index] = vec![token];
                 prompts[index].push_str(&word);
                 num_tokens[index] -= 1;

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -301,7 +301,8 @@ where
             let probs = model.softmax(logits)?;
             if let Some(probs) = &probs[0] {
                 let token = sampler.sample(probs);
-                let word = String::from_utf8(tokenizer.decode(&[token])?)?;
+                let decoded = tokenizer.decode(&[token])?;
+                let word = String::from_utf8_lossy(&decoded);
 
                 model_text += &word;
                 print!("{}", word);

--- a/examples/gen.rs
+++ b/examples/gen.rs
@@ -189,7 +189,8 @@ where
 
         if let Some(probs) = &probs[0] {
             let token = sample(probs, 0.5);
-            let word = String::from_utf8(tokenizer.decode(&[token])?)?;
+            let decoded = tokenizer.decode(&[token])?;
+            let word = String::from_utf8_lossy(&decoded);
             print!("{}", word);
             tokens[0] = vec![token];
         }


### PR DESCRIPTION
I have switched to using `String::from_utf8_lossy()` instead of `String::from_utf8()`.

This is a temporary measure to prevent the program from crashing.

It is necessary because errors were occurring frequently when using Japanese characters.