### PR TITLE
Huggingface tokenizer support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.14"
 serde_json = "1.0"
 thiserror = "1.0"
+tokenizers = { version = "0.15.2"}
 trait-variant = "0.1"
 uid = "0.1"
 wasm-bindgen = "0.2"


### PR DESCRIPTION
Adding Huggingface tokenizer support. This is useful for RWKV models that were trained with a custom tokenizer, especially since RWKV tokenizer training code is not available. Useful for experiments such as per-character tokenizer or custom datasets such as music, timeseries, rare languages etc

Checked with ai00_server and my trained from scratch RWKV model that uses BBPE HF tokenizer - it works 🎉