### PR TITLE
Remove the unnecessary async functions in loader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ trait-variant = "0.1"
 uid = "0.1"
 wasm-bindgen = "0.2"
 wgpu = "22.1.0"
+pollster = "0.3"
 
 [dependencies.web-rwkv-derive]
 path = "crates/web-rwkv-derive"

--- a/src/model/loader.rs
+++ b/src/model/loader.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, future::Future};
+use std::borrow::Cow;
 
 use anyhow::Result;
 use half::f16;
@@ -28,7 +28,7 @@ pub trait Reader {
     fn names(&self) -> Vec<&str>;
     fn contains(&self, name: &str) -> bool;
     fn shape(&self, name: &str) -> Result<Vec<usize>, SafeTensorError>;
-    fn tensor(&self, name: &str) -> impl Future<Output = Result<ReaderTensor, SafeTensorError>>;
+    fn tensor(&self, name: &str) -> Result<ReaderTensor, SafeTensorError>;
 }
 
 impl ReaderSend for SafeTensors<'_> {
@@ -48,8 +48,8 @@ impl ReaderSend for SafeTensors<'_> {
     }
 
     #[inline]
-    async fn tensor(&self, name: &str) -> Result<ReaderTensor, SafeTensorError> {
-        let tensor = self.tensor(name)?;
+    fn tensor(&self, name: &str) -> Result<ReaderTensor, SafeTensorError> {
+        let tensor = SafeTensors::tensor(self, name)?;
         let shape = tensor.shape().to_vec();
         let data = tensor.data().into();
         Ok((tensor.dtype(), shape, data))
@@ -274,7 +274,7 @@ impl<R: Reader> Loader<R> {
                 continue;
             };
 
-            let Ok(tensor) = lora.data.tensor(name).await else {
+            let Ok(tensor) = lora.data.tensor(name) else {
                 continue;
             };
             let tensor = TensorCpu::<f16>::from_reader(tensor)?.transfer_into(context);
@@ -304,10 +304,10 @@ impl<R: Reader> Loader<R> {
             };
 
             let name = name.split('.').filter(|x| !x.contains("weight")).join(".");
-            let Ok(x) = lora.data.tensor(&format!("{name}.lora.0")).await else {
+            let Ok(x) = lora.data.tensor(&format!("{name}.lora.0")) else {
                 continue;
             };
-            let Ok(y) = lora.data.tensor(&format!("{name}.lora.1")).await else {
+            let Ok(y) = lora.data.tensor(&format!("{name}.lora.1")) else {
                 continue;
             };
 
@@ -333,7 +333,7 @@ impl<R: Reader> Loader<R> {
     ) -> Result<TensorGpu<f32, ReadWrite>> {
         use TensorDimension::{Auto, Dimension};
         let context = &self.context;
-        let tensor = self.model.tensor(name.as_ref()).await?;
+        let tensor = self.model.tensor(name.as_ref())?;
         let tensor: TensorGpu<_, _> = TensorCpu::<f16>::from_reader(tensor)?
             .map(|x| x.to_f32())
             .reshape(Auto, Dimension(1), Dimension(1), Dimension(1))?
@@ -366,7 +366,7 @@ impl<R: Reader> Loader<R> {
     ) -> Result<TensorGpu<f32, ReadWrite>> {
         use TensorDimension::{Auto, Dimension};
         let context = &self.context;
-        let tensor = self.model.tensor(name.as_ref()).await?;
+        let tensor = self.model.tensor(name.as_ref())?;
         let tensor: TensorGpu<_, _> = TensorCpu::<f16>::from_reader(tensor)?
             // .map(|x| -x.to_f32().exp())
             .map(|x| x.to_f32())
@@ -403,7 +403,7 @@ impl<R: Reader> Loader<R> {
     ) -> Result<TensorGpu<f32, ReadWrite>> {
         use TensorDimension::{Auto, Dimension};
         let context = &self.context;
-        let tensor = self.model.tensor(name.as_ref()).await?;
+        let tensor = self.model.tensor(name.as_ref())?;
         let tensor: TensorGpu<_, _> = TensorCpu::<f16>::from_reader(tensor)?
             // .map(|x| -x.to_f32().exp())
             // .map(|x| x.exp())
@@ -442,7 +442,7 @@ impl<R: Reader> Loader<R> {
         use TensorDimension::{Auto, Dimension};
         let context = &self.context;
         let lora = self.lora_vectors(name.as_ref()).await?;
-        let tensor = self.model.tensor(name.as_ref()).await?;
+        let tensor = self.model.tensor(name.as_ref())?;
         let tensor = if lora.is_empty() {
             TensorCpu::from_reader(tensor)?
                 .reshape(Auto, Dimension(1), Dimension(1), Dimension(1))?
@@ -488,7 +488,7 @@ impl<R: Reader> Loader<R> {
         name: impl AsRef<str>,
     ) -> Result<TensorGpu<f16, ReadWrite>> {
         let context = &self.context;
-        let tensor = self.model.tensor(name.as_ref()).await?;
+        let tensor = self.model.tensor(name.as_ref())?;
         let tensor: TensorGpu<_, _> = TensorCpu::from_reader(tensor)?.transfer_into(context);
 
         let mut ops = vec![];
@@ -520,7 +520,7 @@ impl<R: Reader> Loader<R> {
         discount: f32,
     ) -> Result<TensorGpu<f16, ReadWrite>> {
         let context = &self.context;
-        let tensor = self.model.tensor(name.as_ref()).await?;
+        let tensor = self.model.tensor(name.as_ref())?;
         let tensor: TensorGpu<_, _> = TensorCpu::<f16>::from_reader(tensor)?
             .map(|x| f16::from_f32(discount * x.to_f32()))
             .transfer_into(context);
@@ -554,7 +554,7 @@ impl<R: Reader> Loader<R> {
         name: impl AsRef<str>,
     ) -> Result<()> {
         let context = &self.context;
-        let tensor = self.model.tensor(name.as_ref()).await?;
+        let tensor = self.model.tensor(name.as_ref())?;
         let tensor = TensorCpu::from_reader(tensor)?;
         matrix.load(&tensor)?;
 
@@ -590,7 +590,7 @@ impl<R: Reader> Loader<R> {
         use TensorDimension::{Dimension, Full};
         let context = &self.context;
 
-        let tensor = self.model.tensor(name.as_ref()).await?;
+        let tensor = self.model.tensor(name.as_ref())?;
         let tensor = TensorCpu::<f16>::from_reader(tensor)?
             .map(|x| f16::from_f32(discount * x.to_f32()))
             .reshape(Full, Full, Dimension(1), Dimension(1))?;
@@ -623,7 +623,7 @@ impl<R: Reader> Loader<R> {
         let context = &self.context;
         let name = "emb.weight";
 
-        let (dt, shape, tensor) = self.model.tensor(name).await?;
+        let (dt, shape, tensor) = self.model.tensor(name)?;
         let lora = self.lora_vectors(name).await?;
 
         if lora.is_empty() {
@@ -646,7 +646,7 @@ impl<R: Reader> Loader<R> {
 
     pub async fn load_head(&self, chunk_size: usize) -> Result<Vec<TensorGpu<f16, ReadWrite>>> {
         let context = &self.context;
-        let (_, shape, tensor) = self.model.tensor("head.weight").await?;
+        let (_, shape, tensor) = self.model.tensor("head.weight")?;
         let shape = Shape::new(shape[1], shape[0], 1, 1);
         let chunks = (shape[1] + chunk_size - 1) / chunk_size;
         let data = bytemuck::cast_slice(&tensor);

--- a/src/model/loader.rs
+++ b/src/model/loader.rs
@@ -607,7 +607,7 @@ impl<R: Reader> Loader<R> {
         Ok(())
     }
 
-    pub async fn load_embed(&self) -> Result<TensorCpu<f16>> {
+    pub fn load_embed(&self) -> Result<TensorCpu<f16>> {
         let context = &self.context;
         let name = "emb.weight";
 
@@ -628,7 +628,7 @@ impl<R: Reader> Loader<R> {
             }
 
             context.queue.submit(context.encode(&TensorOp::List(ops)));
-            Ok(tensor.back().await)
+            Ok(pollster::block_on(tensor.back()))
         }
     }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -238,7 +238,7 @@ impl<R: Reader> ModelBuilder<R> {
         }
     }
 
-    async fn prepare(self) -> Result<PreparedModelBuilder<R>> {
+    fn prepare(self) -> Result<PreparedModelBuilder<R>> {
         let ModelBuilder {
             context,
             model,

--- a/src/model/v4.rs
+++ b/src/model/v4.rs
@@ -408,26 +408,26 @@ impl<R: Reader, F: Float> BuildFuture<Model<F>> for ModelBuilder<R> {
             embed_device,
             turbo,
             token_chunk_size,
-        } = self.prepare().await?;
+        } = self.prepare()?;
 
         let embed = Embed {
             layer_norm: LayerNorm {
-                w: loader.load_vector_f16("blocks.0.ln0.weight").await?,
-                b: loader.load_vector_f16("blocks.0.ln0.bias").await?,
+                w: loader.load_vector_f16("blocks.0.ln0.weight")?,
+                b: loader.load_vector_f16("blocks.0.ln0.bias")?,
             },
             w: loader.load_embed().await?,
             u: match embed_device {
                 super::EmbedDevice::Cpu => None,
-                super::EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight").await?),
+                super::EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight")?),
             },
         };
 
         let head = Head {
             layer_norm: LayerNorm {
-                w: loader.load_vector_f16("ln_out.weight").await?,
-                b: loader.load_vector_f16("ln_out.bias").await?,
+                w: loader.load_vector_f16("ln_out.weight")?,
+                b: loader.load_vector_f16("ln_out.bias")?,
             },
-            w: Matrix::Fp16(loader.load_matrix_f16("head.weight").await?),
+            w: Matrix::Fp16(loader.load_matrix_f16("head.weight")?),
         };
 
         context.queue.submit(None);
@@ -444,22 +444,16 @@ impl<R: Reader, F: Float> BuildFuture<Model<F>> for ModelBuilder<R> {
             let discount = 2.0_f32.powi(-((layer / RESCALE_LAYER) as i32));
 
             let att_layer_norm = LayerNorm {
-                w: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln1.weight"))
-                    .await?,
-                b: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln1.bias"))
-                    .await?,
+                w: loader.load_vector_f16(format!("blocks.{layer}.ln1.weight"))?,
+                b: loader.load_vector_f16(format!("blocks.{layer}.ln1.bias"))?,
             };
 
             let att = format!("blocks.{layer}.att");
-            let time_decay = loader
-                .load_vector_exp_f32(format!("{att}.time_decay"))
-                .await?;
-            let time_first = loader.load_vector_f32(format!("{att}.time_first")).await?;
-            let time_mix_k = loader.load_vector_f16(format!("{att}.time_mix_k")).await?;
-            let time_mix_v = loader.load_vector_f16(format!("{att}.time_mix_v")).await?;
-            let time_mix_r = loader.load_vector_f16(format!("{att}.time_mix_r")).await?;
+            let time_decay = loader.load_vector_exp_f32(format!("{att}.time_decay"))?;
+            let time_first = loader.load_vector_f32(format!("{att}.time_first"))?;
+            let time_mix_k = loader.load_vector_f16(format!("{att}.time_mix_k"))?;
+            let time_mix_v = loader.load_vector_f16(format!("{att}.time_mix_v"))?;
+            let time_mix_r = loader.load_vector_f16(format!("{att}.time_mix_r"))?;
 
             let att = Att {
                 time_decay,
@@ -467,31 +461,27 @@ impl<R: Reader, F: Float> BuildFuture<Model<F>> for ModelBuilder<R> {
                 time_mix_k,
                 time_mix_v,
                 time_mix_r,
-                w_k: load_matrix(format!("{att}.key.weight"), quant).await?,
-                w_v: load_matrix(format!("{att}.value.weight"), quant).await?,
-                w_r: load_matrix(format!("{att}.receptance.weight"), quant).await?,
-                w_o: load_matrix_discount(format!("{att}.output.weight"), quant, discount).await?,
+                w_k: load_matrix(format!("{att}.key.weight"), quant)?,
+                w_v: load_matrix(format!("{att}.value.weight"), quant)?,
+                w_r: load_matrix(format!("{att}.receptance.weight"), quant)?,
+                w_o: load_matrix_discount(format!("{att}.output.weight"), quant, discount)?,
             };
 
             let ffn_layer_norm = LayerNorm {
-                w: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln2.weight"))
-                    .await?,
-                b: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln2.bias"))
-                    .await?,
+                w: loader.load_vector_f16(format!("blocks.{layer}.ln2.weight"))?,
+                b: loader.load_vector_f16(format!("blocks.{layer}.ln2.bias"))?,
             };
 
             let ffn = format!("blocks.{layer}.ffn");
-            let time_mix_k = loader.load_vector_f16(format!("{ffn}.time_mix_k")).await?;
-            let time_mix_r = loader.load_vector_f16(format!("{ffn}.time_mix_r")).await?;
+            let time_mix_k = loader.load_vector_f16(format!("{ffn}.time_mix_k"))?;
+            let time_mix_r = loader.load_vector_f16(format!("{ffn}.time_mix_r"))?;
 
             let ffn = Ffn {
                 time_mix_k,
                 time_mix_r,
-                w_r: load_matrix(format!("{ffn}.receptance.weight"), quant).await?,
-                w_k: load_matrix(format!("{ffn}.key.weight"), quant).await?,
-                w_v: load_matrix_discount(format!("{ffn}.value.weight"), quant, discount).await?,
+                w_r: load_matrix(format!("{ffn}.receptance.weight"), quant)?,
+                w_k: load_matrix(format!("{ffn}.key.weight"), quant)?,
+                w_v: load_matrix_discount(format!("{ffn}.value.weight"), quant, discount)?,
             };
 
             context.queue.submit(None);

--- a/src/model/v4.rs
+++ b/src/model/v4.rs
@@ -415,7 +415,7 @@ impl<R: Reader, F: Float> BuildFuture<Model<F>> for ModelBuilder<R> {
                 w: loader.load_vector_f16("blocks.0.ln0.weight")?,
                 b: loader.load_vector_f16("blocks.0.ln0.bias")?,
             },
-            w: loader.load_embed().await?,
+            w: loader.load_embed()?,
             u: match embed_device {
                 super::EmbedDevice::Cpu => None,
                 super::EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight")?),

--- a/src/model/v5.rs
+++ b/src/model/v5.rs
@@ -473,26 +473,26 @@ impl<R: Reader, F: Float> BuildFuture<Model<F>> for ModelBuilder<R> {
             embed_device,
             turbo,
             token_chunk_size,
-        } = self.prepare().await?;
+        } = self.prepare()?;
 
         let embed = Embed {
             layer_norm: LayerNorm {
-                w: loader.load_vector_f16("blocks.0.ln0.weight").await?,
-                b: loader.load_vector_f16("blocks.0.ln0.bias").await?,
+                w: loader.load_vector_f16("blocks.0.ln0.weight")?,
+                b: loader.load_vector_f16("blocks.0.ln0.bias")?,
             },
             w: loader.load_embed().await?,
             u: match embed_device {
                 super::EmbedDevice::Cpu => None,
-                super::EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight").await?),
+                super::EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight")?),
             },
         };
 
         let head = Head {
             layer_norm: LayerNorm {
-                w: loader.load_vector_f16("ln_out.weight").await?,
-                b: loader.load_vector_f16("ln_out.bias").await?,
+                w: loader.load_vector_f16("ln_out.weight")?,
+                b: loader.load_vector_f16("ln_out.bias")?,
             },
-            w: Matrix::Fp16(loader.load_matrix_f16("head.weight").await?),
+            w: Matrix::Fp16(loader.load_matrix_f16("head.weight")?),
         };
 
         context.queue.submit(None);
@@ -509,28 +509,21 @@ impl<R: Reader, F: Float> BuildFuture<Model<F>> for ModelBuilder<R> {
             let discount = 2.0_f32.powi(-((layer / RESCALE_LAYER) as i32));
 
             let att_layer_norm = LayerNorm {
-                w: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln1.weight"))
-                    .await?,
-                b: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln1.bias"))
-                    .await?,
+                w: loader.load_vector_f16(format!("blocks.{layer}.ln1.weight"))?,
+                b: loader.load_vector_f16(format!("blocks.{layer}.ln1.bias"))?,
             };
 
             let att = format!("blocks.{layer}.att");
-            let time_decay = loader
-                .load_vector_exp_exp_f32(format!("{att}.time_decay"))
-                .await?;
-            let time_first = loader.load_vector_f32(format!("{att}.time_first")).await?;
-            let time_mix_k = loader.load_vector_f16(format!("{att}.time_mix_k")).await?;
-            let time_mix_v = loader.load_vector_f16(format!("{att}.time_mix_v")).await?;
-            let time_mix_r = loader.load_vector_f16(format!("{att}.time_mix_r")).await?;
-            let time_mix_g = loader.load_vector_f16(format!("{att}.time_mix_g")).await?;
+            let time_decay = loader.load_vector_exp_exp_f32(format!("{att}.time_decay"))?;
+            let time_first = loader.load_vector_f32(format!("{att}.time_first"))?;
+            let time_mix_k = loader.load_vector_f16(format!("{att}.time_mix_k"))?;
+            let time_mix_v = loader.load_vector_f16(format!("{att}.time_mix_v"))?;
+            let time_mix_r = loader.load_vector_f16(format!("{att}.time_mix_r"))?;
+            let time_mix_g = loader.load_vector_f16(format!("{att}.time_mix_g"))?;
 
             let group_norm = LayerNorm {
                 w: loader
-                    .load_vector_f16(format!("{att}.ln_x.weight"))
-                    .await?
+                    .load_vector_f16(format!("{att}.ln_x.weight"))?
                     .reshape(
                         TensorDimension::Auto,
                         TensorDimension::Dimension(info.num_head),
@@ -538,8 +531,7 @@ impl<R: Reader, F: Float> BuildFuture<Model<F>> for ModelBuilder<R> {
                         TensorDimension::Dimension(1),
                     )?,
                 b: loader
-                    .load_vector_f16(format!("{att}.ln_x.bias"))
-                    .await?
+                    .load_vector_f16(format!("{att}.ln_x.bias"))?
                     .reshape(
                         TensorDimension::Auto,
                         TensorDimension::Dimension(info.num_head),
@@ -555,33 +547,29 @@ impl<R: Reader, F: Float> BuildFuture<Model<F>> for ModelBuilder<R> {
                 time_mix_v,
                 time_mix_r,
                 time_mix_g,
-                w_k: load_matrix(format!("{att}.key.weight"), quant).await?,
-                w_v: load_matrix(format!("{att}.value.weight"), quant).await?,
-                w_r: load_matrix(format!("{att}.receptance.weight"), quant).await?,
-                w_g: load_matrix(format!("{att}.gate.weight"), quant).await?,
-                w_o: load_matrix_discount(format!("{att}.output.weight"), quant, discount).await?,
+                w_k: load_matrix(format!("{att}.key.weight"), quant)?,
+                w_v: load_matrix(format!("{att}.value.weight"), quant)?,
+                w_r: load_matrix(format!("{att}.receptance.weight"), quant)?,
+                w_g: load_matrix(format!("{att}.gate.weight"), quant)?,
+                w_o: load_matrix_discount(format!("{att}.output.weight"), quant, discount)?,
                 group_norm,
             };
 
             let ffn_layer_norm = LayerNorm {
-                w: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln2.weight"))
-                    .await?,
-                b: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln2.bias"))
-                    .await?,
+                w: loader.load_vector_f16(format!("blocks.{layer}.ln2.weight"))?,
+                b: loader.load_vector_f16(format!("blocks.{layer}.ln2.bias"))?,
             };
 
             let ffn = format!("blocks.{layer}.ffn");
-            let time_mix_k = loader.load_vector_f16(format!("{ffn}.time_mix_k")).await?;
-            let time_mix_r = loader.load_vector_f16(format!("{ffn}.time_mix_r")).await?;
+            let time_mix_k = loader.load_vector_f16(format!("{ffn}.time_mix_k"))?;
+            let time_mix_r = loader.load_vector_f16(format!("{ffn}.time_mix_r"))?;
 
             let ffn = Ffn {
                 time_mix_k,
                 time_mix_r,
-                w_r: load_matrix(format!("{ffn}.receptance.weight"), quant).await?,
-                w_k: load_matrix(format!("{ffn}.key.weight"), quant).await?,
-                w_v: load_matrix_discount(format!("{ffn}.value.weight"), quant, discount).await?,
+                w_r: load_matrix(format!("{ffn}.receptance.weight"), quant)?,
+                w_k: load_matrix(format!("{ffn}.key.weight"), quant)?,
+                w_v: load_matrix_discount(format!("{ffn}.value.weight"), quant, discount)?,
             };
 
             context.queue.submit(None);

--- a/src/model/v5.rs
+++ b/src/model/v5.rs
@@ -480,7 +480,7 @@ impl<R: Reader, F: Float> BuildFuture<Model<F>> for ModelBuilder<R> {
                 w: loader.load_vector_f16("blocks.0.ln0.weight")?,
                 b: loader.load_vector_f16("blocks.0.ln0.bias")?,
             },
-            w: loader.load_embed().await?,
+            w: loader.load_embed()?,
             u: match embed_device {
                 super::EmbedDevice::Cpu => None,
                 super::EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight")?),

--- a/src/model/v6.rs
+++ b/src/model/v6.rs
@@ -514,26 +514,26 @@ impl<R: Reader, F: Float> BuildFuture<Model<F>> for ModelBuilder<R> {
             embed_device,
             turbo,
             token_chunk_size,
-        } = self.prepare().await?;
+        } = self.prepare()?;
 
         let embed = Embed {
             layer_norm: LayerNorm {
-                w: loader.load_vector_f16("blocks.0.ln0.weight").await?,
-                b: loader.load_vector_f16("blocks.0.ln0.bias").await?,
+                w: loader.load_vector_f16("blocks.0.ln0.weight")?,
+                b: loader.load_vector_f16("blocks.0.ln0.bias")?,
             },
             w: loader.load_embed().await?,
             u: match embed_device {
                 super::EmbedDevice::Cpu => None,
-                super::EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight").await?),
+                super::EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight")?),
             },
         };
 
         let head = Head {
             layer_norm: LayerNorm {
-                w: loader.load_vector_f16("ln_out.weight").await?,
-                b: loader.load_vector_f16("ln_out.bias").await?,
+                w: loader.load_vector_f16("ln_out.weight")?,
+                b: loader.load_vector_f16("ln_out.bias")?,
             },
-            w: Matrix::Fp16(loader.load_matrix_f16("head.weight").await?),
+            w: Matrix::Fp16(loader.load_matrix_f16("head.weight")?),
         };
 
         context.queue.submit(None);
@@ -550,38 +550,29 @@ impl<R: Reader, F: Float> BuildFuture<Model<F>> for ModelBuilder<R> {
             let discount = 2.0_f32.powi(-((layer / RESCALE_LAYER) as i32));
 
             let att_layer_norm = LayerNorm {
-                w: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln1.weight"))
-                    .await?,
-                b: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln1.bias"))
-                    .await?,
+                w: loader.load_vector_f16(format!("blocks.{layer}.ln1.weight"))?,
+                b: loader.load_vector_f16(format!("blocks.{layer}.ln1.bias"))?,
             };
 
             let att = format!("blocks.{layer}.att");
-            let time_decay = loader.load_vector_f16(format!("{att}.time_decay")).await?;
-            let time_first = loader.load_vector_f32(format!("{att}.time_first")).await?;
-            let time_mix_x = loader.load_vector_f16(format!("{att}.time_mix_x")).await?;
-            let time_mix_w = loader.load_vector_f16(format!("{att}.time_mix_w")).await?;
-            let time_mix_k = loader.load_vector_f16(format!("{att}.time_mix_k")).await?;
-            let time_mix_v = loader.load_vector_f16(format!("{att}.time_mix_v")).await?;
-            let time_mix_r = loader.load_vector_f16(format!("{att}.time_mix_r")).await?;
-            let time_mix_g = loader.load_vector_f16(format!("{att}.time_mix_g")).await?;
+            let time_decay = loader.load_vector_f16(format!("{att}.time_decay"))?;
+            let time_first = loader.load_vector_f32(format!("{att}.time_first"))?;
+            let time_mix_x = loader.load_vector_f16(format!("{att}.time_mix_x"))?;
+            let time_mix_w = loader.load_vector_f16(format!("{att}.time_mix_w"))?;
+            let time_mix_k = loader.load_vector_f16(format!("{att}.time_mix_k"))?;
+            let time_mix_v = loader.load_vector_f16(format!("{att}.time_mix_v"))?;
+            let time_mix_r = loader.load_vector_f16(format!("{att}.time_mix_r"))?;
+            let time_mix_g = loader.load_vector_f16(format!("{att}.time_mix_g"))?;
 
-            let time_decay_w1 = loader
-                .load_matrix_f16(format!("{att}.time_decay_w1"))
-                .await?;
-            let time_decay_w2 = loader
-                .load_matrix_f16(format!("{att}.time_decay_w2"))
-                .await?;
+            let time_decay_w1 = loader.load_matrix_f16(format!("{att}.time_decay_w1"))?;
+            let time_decay_w2 = loader.load_matrix_f16(format!("{att}.time_decay_w2"))?;
 
-            let time_mix_w1 = loader.load_matrix_f16(format!("{att}.time_mix_w1")).await?;
-            let time_mix_w2 = loader.load_matrix_f16(format!("{att}.time_mix_w2")).await?;
+            let time_mix_w1 = loader.load_matrix_f16(format!("{att}.time_mix_w1"))?;
+            let time_mix_w2 = loader.load_matrix_f16(format!("{att}.time_mix_w2"))?;
 
             let group_norm = LayerNorm {
                 w: loader
-                    .load_vector_f16(format!("{att}.ln_x.weight"))
-                    .await?
+                    .load_vector_f16(format!("{att}.ln_x.weight"))?
                     .reshape(
                         TensorDimension::Auto,
                         TensorDimension::Dimension(info.num_head),
@@ -589,8 +580,7 @@ impl<R: Reader, F: Float> BuildFuture<Model<F>> for ModelBuilder<R> {
                         TensorDimension::Dimension(1),
                     )?,
                 b: loader
-                    .load_vector_f16(format!("{att}.ln_x.bias"))
-                    .await?
+                    .load_vector_f16(format!("{att}.ln_x.bias"))?
                     .reshape(
                         TensorDimension::Auto,
                         TensorDimension::Dimension(info.num_head),
@@ -612,33 +602,29 @@ impl<R: Reader, F: Float> BuildFuture<Model<F>> for ModelBuilder<R> {
                 time_decay_w2: Matrix::Fp16(time_decay_w2),
                 time_mix_w1: Matrix::Fp16(time_mix_w1),
                 time_mix_w2: Matrix::Fp16(time_mix_w2),
-                w_k: load_matrix(format!("{att}.key.weight"), quant).await?,
-                w_v: load_matrix(format!("{att}.value.weight"), quant).await?,
-                w_r: load_matrix(format!("{att}.receptance.weight"), quant).await?,
-                w_g: load_matrix(format!("{att}.gate.weight"), quant).await?,
-                w_o: load_matrix_discount(format!("{att}.output.weight"), quant, discount).await?,
+                w_k: load_matrix(format!("{att}.key.weight"), quant)?,
+                w_v: load_matrix(format!("{att}.value.weight"), quant)?,
+                w_r: load_matrix(format!("{att}.receptance.weight"), quant)?,
+                w_g: load_matrix(format!("{att}.gate.weight"), quant)?,
+                w_o: load_matrix_discount(format!("{att}.output.weight"), quant, discount)?,
                 group_norm,
             };
 
             let ffn_layer_norm = LayerNorm {
-                w: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln2.weight"))
-                    .await?,
-                b: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln2.bias"))
-                    .await?,
+                w: loader.load_vector_f16(format!("blocks.{layer}.ln2.weight"))?,
+                b: loader.load_vector_f16(format!("blocks.{layer}.ln2.bias"))?,
             };
 
             let ffn = format!("blocks.{layer}.ffn");
-            let time_mix_k = loader.load_vector_f16(format!("{ffn}.time_mix_k")).await?;
-            let time_mix_r = loader.load_vector_f16(format!("{ffn}.time_mix_r")).await?;
+            let time_mix_k = loader.load_vector_f16(format!("{ffn}.time_mix_k"))?;
+            let time_mix_r = loader.load_vector_f16(format!("{ffn}.time_mix_r"))?;
 
             let ffn = Ffn {
                 time_mix_k,
                 time_mix_r,
-                w_r: load_matrix(format!("{ffn}.receptance.weight"), quant).await?,
-                w_k: load_matrix(format!("{ffn}.key.weight"), quant).await?,
-                w_v: load_matrix_discount(format!("{ffn}.value.weight"), quant, discount).await?,
+                w_r: load_matrix(format!("{ffn}.receptance.weight"), quant)?,
+                w_k: load_matrix(format!("{ffn}.key.weight"), quant)?,
+                w_v: load_matrix_discount(format!("{ffn}.value.weight"), quant, discount)?,
             };
 
             context.queue.submit(None);

--- a/src/model/v6.rs
+++ b/src/model/v6.rs
@@ -521,7 +521,7 @@ impl<R: Reader, F: Float> BuildFuture<Model<F>> for ModelBuilder<R> {
                 w: loader.load_vector_f16("blocks.0.ln0.weight")?,
                 b: loader.load_vector_f16("blocks.0.ln0.bias")?,
             },
-            w: loader.load_embed().await?,
+            w: loader.load_embed()?,
             u: match embed_device {
                 super::EmbedDevice::Cpu => None,
                 super::EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight")?),

--- a/src/runtime/loader.rs
+++ b/src/runtime/loader.rs
@@ -606,7 +606,7 @@ impl<R: Reader> Loader<R> {
         Ok(())
     }
 
-    pub async fn load_embed(&self) -> Result<TensorCpu<f16>> {
+    pub fn load_embed(&self) -> Result<TensorCpu<f16>> {
         let context = &self.context;
         let name = "emb.weight";
 
@@ -626,7 +626,7 @@ impl<R: Reader> Loader<R> {
                 ops.push(op);
             }
             context.queue.submit(context.encode(&TensorOp::List(ops)));
-            Ok(tensor.back().await)
+            Ok(pollster::block_on(tensor.back()))
         }
     }
 

--- a/src/runtime/loader.rs
+++ b/src/runtime/loader.rs
@@ -258,7 +258,7 @@ impl<R: Reader> Loader<R> {
 
     /// Load all lora and blend factors about the vector with a given name.
     /// In each LoRA, only the last matched pattern is loaded.
-    async fn lora_vectors(&self, name: impl AsRef<str>) -> Result<Vec<LoraVector>> {
+    fn lora_vectors(&self, name: impl AsRef<str>) -> Result<Vec<LoraVector>> {
         let context = &self.context;
         let name = name.as_ref();
 
@@ -287,7 +287,7 @@ impl<R: Reader> Loader<R> {
 
     /// Load all lora and blend factors about the matrix with a given name.
     /// In each LoRA, only the last matched pattern is loaded.
-    async fn lora_matrices(&self, name: impl AsRef<str>) -> Result<Vec<LoraMatrix>> {
+    fn lora_matrices(&self, name: impl AsRef<str>) -> Result<Vec<LoraMatrix>> {
         let context = &self.context;
         let name = name.as_ref();
 
@@ -326,10 +326,7 @@ impl<R: Reader> Loader<R> {
         Ok(Shape::from_slice_rev(&shape)?)
     }
 
-    pub async fn load_vector_f32(
-        &self,
-        name: impl AsRef<str>,
-    ) -> Result<TensorGpu<f32, ReadWrite>> {
+    pub fn load_vector_f32(&self, name: impl AsRef<str>) -> Result<TensorGpu<f32, ReadWrite>> {
         use TensorDimension::{Auto, Dimension};
         let context = &self.context;
         let tensor = self.model.tensor(name.as_ref())?;
@@ -339,7 +336,7 @@ impl<R: Reader> Loader<R> {
             .transfer_into(context);
 
         let mut ops = vec![];
-        for lora in self.lora_vectors(name).await? {
+        for lora in self.lora_vectors(name)? {
             let factor = vec![lora.alpha, 1.0 - lora.alpha, 0.0, 0.0];
             let factor = context.tensor_from_data([4, 1, 1, 1], factor)?;
 
@@ -359,10 +356,7 @@ impl<R: Reader> Loader<R> {
         Ok(tensor)
     }
 
-    pub async fn load_vector_exp_f32(
-        &self,
-        name: impl AsRef<str>,
-    ) -> Result<TensorGpu<f32, ReadWrite>> {
+    pub fn load_vector_exp_f32(&self, name: impl AsRef<str>) -> Result<TensorGpu<f32, ReadWrite>> {
         use TensorDimension::{Auto, Dimension};
         let context = &self.context;
         let tensor = self.model.tensor(name.as_ref())?;
@@ -373,7 +367,7 @@ impl<R: Reader> Loader<R> {
             .transfer_into(context);
 
         let mut ops = vec![];
-        for lora in self.lora_vectors(name).await? {
+        for lora in self.lora_vectors(name)? {
             let factor = vec![lora.alpha, 1.0 - lora.alpha, 0.0, 0.0];
             let factor = context.tensor_from_data([4, 1, 1, 1], factor)?;
 
@@ -396,7 +390,7 @@ impl<R: Reader> Loader<R> {
         Ok(tensor)
     }
 
-    pub async fn load_vector_exp_exp_f32(
+    pub fn load_vector_exp_exp_f32(
         &self,
         name: impl AsRef<str>,
     ) -> Result<TensorGpu<f32, ReadWrite>> {
@@ -411,7 +405,7 @@ impl<R: Reader> Loader<R> {
             .transfer_into(context);
 
         let mut ops = vec![];
-        for lora in self.lora_vectors(name).await? {
+        for lora in self.lora_vectors(name)? {
             let factor = vec![lora.alpha, 1.0 - lora.alpha, 0.0, 0.0];
             let factor = context.tensor_from_data([4, 1, 1, 1], factor)?;
 
@@ -434,13 +428,10 @@ impl<R: Reader> Loader<R> {
         Ok(tensor)
     }
 
-    pub async fn load_vector_f16(
-        &self,
-        name: impl AsRef<str>,
-    ) -> Result<TensorGpu<f16, ReadWrite>> {
+    pub fn load_vector_f16(&self, name: impl AsRef<str>) -> Result<TensorGpu<f16, ReadWrite>> {
         use TensorDimension::{Auto, Dimension};
         let context = &self.context;
-        let lora = self.lora_vectors(name.as_ref()).await?;
+        let lora = self.lora_vectors(name.as_ref())?;
         let tensor = self.model.tensor(name.as_ref())?;
         let tensor = if lora.is_empty() {
             TensorCpu::from_reader(tensor)?
@@ -482,16 +473,13 @@ impl<R: Reader> Loader<R> {
         Ok(tensor)
     }
 
-    pub async fn load_matrix_f16(
-        &self,
-        name: impl AsRef<str>,
-    ) -> Result<TensorGpu<f16, ReadWrite>> {
+    pub fn load_matrix_f16(&self, name: impl AsRef<str>) -> Result<TensorGpu<f16, ReadWrite>> {
         let context = &self.context;
         let tensor = self.model.tensor(name.as_ref())?;
         let tensor: TensorGpu<_, _> = TensorCpu::from_reader(tensor)?.transfer_into(context);
 
         let mut ops = vec![];
-        for lora in self.lora_matrices(name.as_ref()).await? {
+        for lora in self.lora_matrices(name.as_ref())? {
             let factor = vec![lora.alpha / lora.rank as f32, 1.0, 0.0, 0.0];
             let factor = context.tensor_from_data([4, 1, 1, 1], factor)?;
             let op = TensorOp::blend_lora(
@@ -502,7 +490,7 @@ impl<R: Reader> Loader<R> {
             )?;
             ops.push(op);
         }
-        for lora in self.lora_vectors(name.as_ref()).await? {
+        for lora in self.lora_vectors(name.as_ref())? {
             let factor = vec![lora.alpha, 1.0, 0.0, 0.0];
             let factor = context.tensor_from_data([4, 1, 1, 1], factor)?;
             let op = TensorOp::blend(&factor, &lora.tensor, &tensor)?;
@@ -513,7 +501,7 @@ impl<R: Reader> Loader<R> {
         Ok(tensor)
     }
 
-    pub async fn load_matrix_f16_discount(
+    pub fn load_matrix_f16_discount(
         &self,
         name: impl AsRef<str>,
         discount: f32,
@@ -525,7 +513,7 @@ impl<R: Reader> Loader<R> {
             .transfer_into(context);
 
         let mut ops = vec![];
-        for lora in self.lora_matrices(name.as_ref()).await? {
+        for lora in self.lora_matrices(name.as_ref())? {
             let factor = vec![discount * lora.alpha / lora.rank as f32, 1.0, 0.0, 0.0];
             let factor = context.tensor_from_data([4, 1, 1, 1], factor)?;
             let op = TensorOp::blend_lora(
@@ -536,7 +524,7 @@ impl<R: Reader> Loader<R> {
             )?;
             ops.push(op);
         }
-        for lora in self.lora_vectors(name.as_ref()).await? {
+        for lora in self.lora_vectors(name.as_ref())? {
             let factor = vec![discount * lora.alpha, 1.0, 0.0, 0.0];
             let factor = context.tensor_from_data([4, 1, 1, 1], factor)?;
             let op = TensorOp::blend(&factor, &lora.tensor, &tensor)?;
@@ -547,7 +535,7 @@ impl<R: Reader> Loader<R> {
         Ok(tensor)
     }
 
-    pub async fn load_in_place_matrix_f16(
+    pub fn load_in_place_matrix_f16(
         &self,
         matrix: &TensorGpu<f16, ReadWrite>,
         name: impl AsRef<str>,
@@ -558,7 +546,7 @@ impl<R: Reader> Loader<R> {
         matrix.load(&tensor)?;
 
         let mut ops = vec![];
-        for lora in self.lora_matrices(name.as_ref()).await? {
+        for lora in self.lora_matrices(name.as_ref())? {
             let factor = vec![lora.alpha / lora.rank as f32, 1.0, 0.0, 0.0];
             let factor = context.tensor_from_data([4, 1, 1, 1], factor)?;
             let op = TensorOp::blend_lora(
@@ -569,7 +557,7 @@ impl<R: Reader> Loader<R> {
             )?;
             ops.push(op);
         }
-        for lora in self.lora_vectors(name.as_ref()).await? {
+        for lora in self.lora_vectors(name.as_ref())? {
             let factor = vec![lora.alpha, 1.0, 0.0, 0.0];
             let factor = context.tensor_from_data([4, 1, 1, 1], factor)?;
             let op = TensorOp::blend(&factor, &lora.tensor, matrix)?;
@@ -580,7 +568,7 @@ impl<R: Reader> Loader<R> {
         Ok(())
     }
 
-    pub async fn load_in_place_matrix_f16_discount(
+    pub fn load_in_place_matrix_f16_discount(
         &self,
         matrix: &TensorGpu<f16, ReadWrite>,
         name: impl AsRef<str>,
@@ -596,7 +584,7 @@ impl<R: Reader> Loader<R> {
         matrix.load(&tensor)?;
 
         let mut ops = vec![];
-        for lora in self.lora_matrices(name.as_ref()).await? {
+        for lora in self.lora_matrices(name.as_ref())? {
             let factor = vec![discount * lora.alpha / lora.rank as f32, 1.0, 0.0, 0.0];
             let factor = context.tensor_from_data([4, 1, 1, 1], factor)?;
             let op = TensorOp::blend_lora(
@@ -607,7 +595,7 @@ impl<R: Reader> Loader<R> {
             )?;
             ops.push(op);
         }
-        for lora in self.lora_vectors(name.as_ref()).await? {
+        for lora in self.lora_vectors(name.as_ref())? {
             let factor = vec![discount * lora.alpha, 1.0, 0.0, 0.0];
             let factor = context.tensor_from_data([4, 1, 1, 1], factor)?;
             let op = TensorOp::blend(&factor, &lora.tensor, matrix)?;
@@ -623,7 +611,7 @@ impl<R: Reader> Loader<R> {
         let name = "emb.weight";
 
         let (dt, shape, tensor) = self.model.tensor(name)?;
-        let lora = self.lora_vectors(name).await?;
+        let lora = self.lora_vectors(name)?;
 
         if lora.is_empty() {
             let tensor = TensorCpu::from_reader((dt, shape, tensor))?;
@@ -642,7 +630,7 @@ impl<R: Reader> Loader<R> {
         }
     }
 
-    pub async fn load_head(&self, chunk_size: usize) -> Result<Vec<TensorGpu<f16, ReadWrite>>> {
+    pub fn load_head(&self, chunk_size: usize) -> Result<Vec<TensorGpu<f16, ReadWrite>>> {
         let context = &self.context;
         let (_, shape, tensor) = self.model.tensor("head.weight")?;
         let shape = Shape::new(shape[1], shape[0], 1, 1);
@@ -660,26 +648,26 @@ impl<R: Reader> Loader<R> {
         Ok(head)
     }
 
-    pub async fn load_matrix(&self, name: String, quant: Quant) -> Result<Matrix> {
+    pub fn load_matrix(&self, name: String, quant: Quant) -> Result<Matrix> {
         let context = &self.context;
         match quant {
-            Quant::None => Ok(Matrix::Fp16(self.load_matrix_f16(name).await?)),
+            Quant::None => Ok(Matrix::Fp16(self.load_matrix_f16(name)?)),
             Quant::Int8 => {
                 let shape = self.tensor_shape(&name)?;
                 let buffer = context.tensor_init(shape);
-                self.load_in_place_matrix_f16(&buffer, &name).await?;
+                self.load_in_place_matrix_f16(&buffer, &name)?;
                 Ok(Matrix::quant_u8(&buffer)?)
             }
             Quant::NF4 => {
                 let shape = self.tensor_shape(&name)?;
                 let buffer = context.tensor_init(shape);
-                self.load_in_place_matrix_f16(&buffer, &name).await?;
+                self.load_in_place_matrix_f16(&buffer, &name)?;
                 Ok(Matrix::quant_nf4(&buffer)?)
             }
         }
     }
 
-    pub async fn load_matrix_discount(
+    pub fn load_matrix_discount(
         &self,
         name: String,
         quant: Quant,
@@ -687,21 +675,17 @@ impl<R: Reader> Loader<R> {
     ) -> Result<Matrix> {
         let context = &self.context;
         match quant {
-            Quant::None => Ok(Matrix::Fp16(
-                self.load_matrix_f16_discount(name, discount).await?,
-            )),
+            Quant::None => Ok(Matrix::Fp16(self.load_matrix_f16_discount(name, discount)?)),
             Quant::Int8 => {
                 let shape = self.tensor_shape(&name)?;
                 let buffer = context.tensor_init(shape);
-                self.load_in_place_matrix_f16_discount(&buffer, &name, discount)
-                    .await?;
+                self.load_in_place_matrix_f16_discount(&buffer, &name, discount)?;
                 Ok(Matrix::quant_u8(&buffer)?)
             }
             Quant::NF4 => {
                 let shape = self.tensor_shape(&name)?;
                 let buffer = context.tensor_init(shape);
-                self.load_in_place_matrix_f16_discount(&buffer, &name, discount)
-                    .await?;
+                self.load_in_place_matrix_f16_discount(&buffer, &name, discount)?;
                 Ok(Matrix::quant_nf4(&buffer)?)
             }
         }

--- a/src/runtime/v4.rs
+++ b/src/runtime/v4.rs
@@ -872,22 +872,22 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
 
         let embed = Embed {
             layer_norm: LayerNorm {
-                w: loader.load_vector_f16("blocks.0.ln0.weight").await?,
-                b: loader.load_vector_f16("blocks.0.ln0.bias").await?,
+                w: loader.load_vector_f16("blocks.0.ln0.weight")?,
+                b: loader.load_vector_f16("blocks.0.ln0.bias")?,
             },
             w: loader.load_embed().await?,
             u: match embed_device {
                 EmbedDevice::Cpu => None,
-                EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight").await?),
+                EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight")?),
             },
         };
 
         let head = Head {
             layer_norm: LayerNorm {
-                w: loader.load_vector_f16("ln_out.weight").await?,
-                b: loader.load_vector_f16("ln_out.bias").await?,
+                w: loader.load_vector_f16("ln_out.weight")?,
+                b: loader.load_vector_f16("ln_out.bias")?,
             },
-            w: Matrix::Fp16(loader.load_matrix_f16("head.weight").await?),
+            w: Matrix::Fp16(loader.load_matrix_f16("head.weight")?),
         };
 
         context.queue.submit(None);
@@ -904,22 +904,16 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
             let discount = 2.0_f32.powi(-((layer / rescale) as i32));
 
             let att_layer_norm = LayerNorm {
-                w: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln1.weight"))
-                    .await?,
-                b: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln1.bias"))
-                    .await?,
+                w: loader.load_vector_f16(format!("blocks.{layer}.ln1.weight"))?,
+                b: loader.load_vector_f16(format!("blocks.{layer}.ln1.bias"))?,
             };
 
             let att = format!("blocks.{layer}.att");
-            let time_decay = loader
-                .load_vector_exp_f32(format!("{att}.time_decay"))
-                .await?;
-            let time_first = loader.load_vector_f32(format!("{att}.time_first")).await?;
-            let time_mix_k = loader.load_vector_f16(format!("{att}.time_mix_k")).await?;
-            let time_mix_v = loader.load_vector_f16(format!("{att}.time_mix_v")).await?;
-            let time_mix_r = loader.load_vector_f16(format!("{att}.time_mix_r")).await?;
+            let time_decay = loader.load_vector_exp_f32(format!("{att}.time_decay"))?;
+            let time_first = loader.load_vector_f32(format!("{att}.time_first"))?;
+            let time_mix_k = loader.load_vector_f16(format!("{att}.time_mix_k"))?;
+            let time_mix_v = loader.load_vector_f16(format!("{att}.time_mix_v"))?;
+            let time_mix_r = loader.load_vector_f16(format!("{att}.time_mix_r"))?;
 
             let att = Att {
                 time_decay,
@@ -927,31 +921,27 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
                 time_mix_k,
                 time_mix_v,
                 time_mix_r,
-                w_k: load_matrix(format!("{att}.key.weight"), quant).await?,
-                w_v: load_matrix(format!("{att}.value.weight"), quant).await?,
-                w_r: load_matrix(format!("{att}.receptance.weight"), quant).await?,
-                w_o: load_matrix_discount(format!("{att}.output.weight"), quant, discount).await?,
+                w_k: load_matrix(format!("{att}.key.weight"), quant)?,
+                w_v: load_matrix(format!("{att}.value.weight"), quant)?,
+                w_r: load_matrix(format!("{att}.receptance.weight"), quant)?,
+                w_o: load_matrix_discount(format!("{att}.output.weight"), quant, discount)?,
             };
 
             let ffn_layer_norm = LayerNorm {
-                w: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln2.weight"))
-                    .await?,
-                b: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln2.bias"))
-                    .await?,
+                w: loader.load_vector_f16(format!("blocks.{layer}.ln2.weight"))?,
+                b: loader.load_vector_f16(format!("blocks.{layer}.ln2.bias"))?,
             };
 
             let ffn = format!("blocks.{layer}.ffn");
-            let time_mix_k = loader.load_vector_f16(format!("{ffn}.time_mix_k")).await?;
-            let time_mix_r = loader.load_vector_f16(format!("{ffn}.time_mix_r")).await?;
+            let time_mix_k = loader.load_vector_f16(format!("{ffn}.time_mix_k"))?;
+            let time_mix_r = loader.load_vector_f16(format!("{ffn}.time_mix_r"))?;
 
             let ffn = Ffn {
                 time_mix_k,
                 time_mix_r,
-                w_r: load_matrix(format!("{ffn}.receptance.weight"), quant).await?,
-                w_k: load_matrix(format!("{ffn}.key.weight"), quant).await?,
-                w_v: load_matrix_discount(format!("{ffn}.value.weight"), quant, discount).await?,
+                w_r: load_matrix(format!("{ffn}.receptance.weight"), quant)?,
+                w_k: load_matrix(format!("{ffn}.key.weight"), quant)?,
+                w_v: load_matrix_discount(format!("{ffn}.value.weight"), quant, discount)?,
             };
 
             context.queue.submit(None);

--- a/src/runtime/v4.rs
+++ b/src/runtime/v4.rs
@@ -875,7 +875,7 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
                 w: loader.load_vector_f16("blocks.0.ln0.weight")?,
                 b: loader.load_vector_f16("blocks.0.ln0.bias")?,
             },
-            w: loader.load_embed().await?,
+            w: loader.load_embed()?,
             u: match embed_device {
                 EmbedDevice::Cpu => None,
                 EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight")?),

--- a/src/runtime/v5.rs
+++ b/src/runtime/v5.rs
@@ -955,7 +955,7 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
                 w: loader.load_vector_f16("blocks.0.ln0.weight")?,
                 b: loader.load_vector_f16("blocks.0.ln0.bias")?,
             },
-            w: loader.load_embed().await?,
+            w: loader.load_embed()?,
             u: match embed_device {
                 EmbedDevice::Cpu => None,
                 EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight")?),

--- a/src/runtime/v5.rs
+++ b/src/runtime/v5.rs
@@ -952,22 +952,22 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
 
         let embed = Embed {
             layer_norm: LayerNorm {
-                w: loader.load_vector_f16("blocks.0.ln0.weight").await?,
-                b: loader.load_vector_f16("blocks.0.ln0.bias").await?,
+                w: loader.load_vector_f16("blocks.0.ln0.weight")?,
+                b: loader.load_vector_f16("blocks.0.ln0.bias")?,
             },
             w: loader.load_embed().await?,
             u: match embed_device {
                 EmbedDevice::Cpu => None,
-                EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight").await?),
+                EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight")?),
             },
         };
 
         let head = Head {
             layer_norm: LayerNorm {
-                w: loader.load_vector_f16("ln_out.weight").await?,
-                b: loader.load_vector_f16("ln_out.bias").await?,
+                w: loader.load_vector_f16("ln_out.weight")?,
+                b: loader.load_vector_f16("ln_out.bias")?,
             },
-            w: Matrix::Fp16(loader.load_matrix_f16("head.weight").await?),
+            w: Matrix::Fp16(loader.load_matrix_f16("head.weight")?),
         };
 
         context.queue.submit(None);
@@ -984,28 +984,21 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
             let discount = 2.0_f32.powi(-((layer / rescale) as i32));
 
             let att_layer_norm = LayerNorm {
-                w: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln1.weight"))
-                    .await?,
-                b: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln1.bias"))
-                    .await?,
+                w: loader.load_vector_f16(format!("blocks.{layer}.ln1.weight"))?,
+                b: loader.load_vector_f16(format!("blocks.{layer}.ln1.bias"))?,
             };
 
             let att = format!("blocks.{layer}.att");
-            let time_decay = loader
-                .load_vector_exp_exp_f32(format!("{att}.time_decay"))
-                .await?;
-            let time_first = loader.load_vector_f32(format!("{att}.time_first")).await?;
-            let time_mix_k = loader.load_vector_f16(format!("{att}.time_mix_k")).await?;
-            let time_mix_v = loader.load_vector_f16(format!("{att}.time_mix_v")).await?;
-            let time_mix_r = loader.load_vector_f16(format!("{att}.time_mix_r")).await?;
-            let time_mix_g = loader.load_vector_f16(format!("{att}.time_mix_g")).await?;
+            let time_decay = loader.load_vector_exp_exp_f32(format!("{att}.time_decay"))?;
+            let time_first = loader.load_vector_f32(format!("{att}.time_first"))?;
+            let time_mix_k = loader.load_vector_f16(format!("{att}.time_mix_k"))?;
+            let time_mix_v = loader.load_vector_f16(format!("{att}.time_mix_v"))?;
+            let time_mix_r = loader.load_vector_f16(format!("{att}.time_mix_r"))?;
+            let time_mix_g = loader.load_vector_f16(format!("{att}.time_mix_g"))?;
 
             let group_norm = LayerNorm {
                 w: loader
-                    .load_vector_f16(format!("{att}.ln_x.weight"))
-                    .await?
+                    .load_vector_f16(format!("{att}.ln_x.weight"))?
                     .reshape(
                         TensorDimension::Auto,
                         TensorDimension::Dimension(info.num_head),
@@ -1013,8 +1006,7 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
                         TensorDimension::Dimension(1),
                     )?,
                 b: loader
-                    .load_vector_f16(format!("{att}.ln_x.bias"))
-                    .await?
+                    .load_vector_f16(format!("{att}.ln_x.bias"))?
                     .reshape(
                         TensorDimension::Auto,
                         TensorDimension::Dimension(info.num_head),
@@ -1030,33 +1022,29 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
                 time_mix_v,
                 time_mix_r,
                 time_mix_g,
-                w_k: load_matrix(format!("{att}.key.weight"), quant).await?,
-                w_v: load_matrix(format!("{att}.value.weight"), quant).await?,
-                w_r: load_matrix(format!("{att}.receptance.weight"), quant).await?,
-                w_g: load_matrix(format!("{att}.gate.weight"), quant).await?,
-                w_o: load_matrix_discount(format!("{att}.output.weight"), quant, discount).await?,
+                w_k: load_matrix(format!("{att}.key.weight"), quant)?,
+                w_v: load_matrix(format!("{att}.value.weight"), quant)?,
+                w_r: load_matrix(format!("{att}.receptance.weight"), quant)?,
+                w_g: load_matrix(format!("{att}.gate.weight"), quant)?,
+                w_o: load_matrix_discount(format!("{att}.output.weight"), quant, discount)?,
                 group_norm,
             };
 
             let ffn_layer_norm = LayerNorm {
-                w: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln2.weight"))
-                    .await?,
-                b: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln2.bias"))
-                    .await?,
+                w: loader.load_vector_f16(format!("blocks.{layer}.ln2.weight"))?,
+                b: loader.load_vector_f16(format!("blocks.{layer}.ln2.bias"))?,
             };
 
             let ffn = format!("blocks.{layer}.ffn");
-            let time_mix_k = loader.load_vector_f16(format!("{ffn}.time_mix_k")).await?;
-            let time_mix_r = loader.load_vector_f16(format!("{ffn}.time_mix_r")).await?;
+            let time_mix_k = loader.load_vector_f16(format!("{ffn}.time_mix_k"))?;
+            let time_mix_r = loader.load_vector_f16(format!("{ffn}.time_mix_r"))?;
 
             let ffn = Ffn {
                 time_mix_k,
                 time_mix_r,
-                w_r: load_matrix(format!("{ffn}.receptance.weight"), quant).await?,
-                w_k: load_matrix(format!("{ffn}.key.weight"), quant).await?,
-                w_v: load_matrix_discount(format!("{ffn}.value.weight"), quant, discount).await?,
+                w_r: load_matrix(format!("{ffn}.receptance.weight"), quant)?,
+                w_k: load_matrix(format!("{ffn}.key.weight"), quant)?,
+                w_v: load_matrix_discount(format!("{ffn}.value.weight"), quant, discount)?,
             };
 
             context.queue.submit(None);
@@ -1111,9 +1099,7 @@ pub async fn read_state<R: Reader>(
 
     let mut ops = vec![];
     for layer in 0..info.num_layer {
-        let matrix = loader
-            .load_matrix_f16(format!("blocks.{layer}.att.time_state"))
-            .await?;
+        let matrix = loader.load_matrix_f16(format!("blocks.{layer}.att.time_state"))?;
         let state: TensorGpu<_, _> = context.tensor_init([head_size, info.num_head, head_size, 1]);
         let reshaped: TensorGpu<f16, _> = state.reshape(
             Dimension(info.num_emb),

--- a/src/runtime/v6.rs
+++ b/src/runtime/v6.rs
@@ -1018,22 +1018,22 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
 
         let embed = Embed {
             layer_norm: LayerNorm {
-                w: loader.load_vector_f16("blocks.0.ln0.weight").await?,
-                b: loader.load_vector_f16("blocks.0.ln0.bias").await?,
+                w: loader.load_vector_f16("blocks.0.ln0.weight")?,
+                b: loader.load_vector_f16("blocks.0.ln0.bias")?,
             },
             w: loader.load_embed().await?,
             u: match embed_device {
                 EmbedDevice::Cpu => None,
-                EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight").await?),
+                EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight")?),
             },
         };
 
         let head = Head {
             layer_norm: LayerNorm {
-                w: loader.load_vector_f16("ln_out.weight").await?,
-                b: loader.load_vector_f16("ln_out.bias").await?,
+                w: loader.load_vector_f16("ln_out.weight")?,
+                b: loader.load_vector_f16("ln_out.bias")?,
             },
-            w: Matrix::Fp16(loader.load_matrix_f16("head.weight").await?),
+            w: Matrix::Fp16(loader.load_matrix_f16("head.weight")?),
         };
 
         context.queue.submit(None);
@@ -1050,25 +1050,21 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
             let discount = 2.0_f32.powi(-((layer / rescale) as i32));
 
             let att_layer_norm = LayerNorm {
-                w: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln1.weight"))
-                    .await?,
-                b: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln1.bias"))
-                    .await?,
+                w: loader.load_vector_f16(format!("blocks.{layer}.ln1.weight"))?,
+                b: loader.load_vector_f16(format!("blocks.{layer}.ln1.bias"))?,
             };
 
             let att = format!("blocks.{layer}.att");
-            let time_decay = loader.load_vector_f16(format!("{att}.time_decay")).await?;
-            let time_first = loader.load_vector_f32(format!("{att}.time_first")).await?;
-            let time_mix_x = loader.load_vector_f16(format!("{att}.time_mix_x")).await?;
+            let time_decay = loader.load_vector_f16(format!("{att}.time_decay"))?;
+            let time_first = loader.load_vector_f32(format!("{att}.time_first"))?;
+            let time_mix_x = loader.load_vector_f16(format!("{att}.time_mix_x"))?;
             let time_mix = {
                 let time_mix: TensorGpu<_, _> = context.zeros([info.num_emb, 1, 5, 1]);
-                let time_mix_w = loader.load_vector_f16(format!("{att}.time_mix_w")).await?;
-                let time_mix_k = loader.load_vector_f16(format!("{att}.time_mix_k")).await?;
-                let time_mix_v = loader.load_vector_f16(format!("{att}.time_mix_v")).await?;
-                let time_mix_r = loader.load_vector_f16(format!("{att}.time_mix_r")).await?;
-                let time_mix_g = loader.load_vector_f16(format!("{att}.time_mix_g")).await?;
+                let time_mix_w = loader.load_vector_f16(format!("{att}.time_mix_w"))?;
+                let time_mix_k = loader.load_vector_f16(format!("{att}.time_mix_k"))?;
+                let time_mix_v = loader.load_vector_f16(format!("{att}.time_mix_v"))?;
+                let time_mix_r = loader.load_vector_f16(format!("{att}.time_mix_r"))?;
+                let time_mix_g = loader.load_vector_f16(format!("{att}.time_mix_g"))?;
 
                 let ops = TensorOp::List(vec![
                     TensorOp::blit(
@@ -1096,20 +1092,15 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
                 time_mix
             };
 
-            let time_decay_w1 = loader
-                .load_matrix_f16(format!("{att}.time_decay_w1"))
-                .await?;
-            let time_decay_w2 = loader
-                .load_matrix_f16(format!("{att}.time_decay_w2"))
-                .await?;
+            let time_decay_w1 = loader.load_matrix_f16(format!("{att}.time_decay_w1"))?;
+            let time_decay_w2 = loader.load_matrix_f16(format!("{att}.time_decay_w2"))?;
 
-            let time_mix_w1 = loader.load_matrix_f16(format!("{att}.time_mix_w1")).await?;
-            let time_mix_w2 = loader.load_matrix_f16(format!("{att}.time_mix_w2")).await?;
+            let time_mix_w1 = loader.load_matrix_f16(format!("{att}.time_mix_w1"))?;
+            let time_mix_w2 = loader.load_matrix_f16(format!("{att}.time_mix_w2"))?;
 
             let group_norm = LayerNorm {
                 w: loader
-                    .load_vector_f16(format!("{att}.ln_x.weight"))
-                    .await?
+                    .load_vector_f16(format!("{att}.ln_x.weight"))?
                     .reshape(
                         TensorDimension::Auto,
                         TensorDimension::Dimension(info.num_head),
@@ -1117,8 +1108,7 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
                         TensorDimension::Dimension(1),
                     )?,
                 b: loader
-                    .load_vector_f16(format!("{att}.ln_x.bias"))
-                    .await?
+                    .load_vector_f16(format!("{att}.ln_x.bias"))?
                     .reshape(
                         TensorDimension::Auto,
                         TensorDimension::Dimension(info.num_head),
@@ -1136,33 +1126,29 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
                 time_decay_w2: Matrix::Fp16(time_decay_w2),
                 time_mix_w1: Matrix::Fp16(time_mix_w1),
                 time_mix_w2: Matrix::Fp16(time_mix_w2),
-                w_k: load_matrix(format!("{att}.key.weight"), quant).await?,
-                w_v: load_matrix(format!("{att}.value.weight"), quant).await?,
-                w_r: load_matrix(format!("{att}.receptance.weight"), quant).await?,
-                w_g: load_matrix(format!("{att}.gate.weight"), quant).await?,
-                w_o: load_matrix_discount(format!("{att}.output.weight"), quant, discount).await?,
+                w_k: load_matrix(format!("{att}.key.weight"), quant)?,
+                w_v: load_matrix(format!("{att}.value.weight"), quant)?,
+                w_r: load_matrix(format!("{att}.receptance.weight"), quant)?,
+                w_g: load_matrix(format!("{att}.gate.weight"), quant)?,
+                w_o: load_matrix_discount(format!("{att}.output.weight"), quant, discount)?,
                 group_norm,
             };
 
             let ffn_layer_norm = LayerNorm {
-                w: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln2.weight"))
-                    .await?,
-                b: loader
-                    .load_vector_f16(format!("blocks.{layer}.ln2.bias"))
-                    .await?,
+                w: loader.load_vector_f16(format!("blocks.{layer}.ln2.weight"))?,
+                b: loader.load_vector_f16(format!("blocks.{layer}.ln2.bias"))?,
             };
 
             let ffn = format!("blocks.{layer}.ffn");
-            let time_mix_k = loader.load_vector_f16(format!("{ffn}.time_mix_k")).await?;
-            let time_mix_r = loader.load_vector_f16(format!("{ffn}.time_mix_r")).await?;
+            let time_mix_k = loader.load_vector_f16(format!("{ffn}.time_mix_k"))?;
+            let time_mix_r = loader.load_vector_f16(format!("{ffn}.time_mix_r"))?;
 
             let ffn = Ffn {
                 time_mix_k,
                 time_mix_r,
-                w_r: load_matrix(format!("{ffn}.receptance.weight"), quant).await?,
-                w_k: load_matrix(format!("{ffn}.key.weight"), quant).await?,
-                w_v: load_matrix_discount(format!("{ffn}.value.weight"), quant, discount).await?,
+                w_r: load_matrix(format!("{ffn}.receptance.weight"), quant)?,
+                w_k: load_matrix(format!("{ffn}.key.weight"), quant)?,
+                w_v: load_matrix_discount(format!("{ffn}.value.weight"), quant, discount)?,
             };
 
             context.queue.submit(None);
@@ -1217,9 +1203,7 @@ pub async fn read_state<R: Reader>(
 
     let mut ops = vec![];
     for layer in 0..info.num_layer {
-        let matrix = loader
-            .load_matrix_f16(format!("blocks.{layer}.att.time_state"))
-            .await?;
+        let matrix = loader.load_matrix_f16(format!("blocks.{layer}.att.time_state"))?;
         let state: TensorGpu<_, _> = context.tensor_init([head_size, info.num_head, head_size, 1]);
         let reshaped: TensorGpu<f16, _> = state.reshape(
             Dimension(info.num_emb),

--- a/src/runtime/v6.rs
+++ b/src/runtime/v6.rs
@@ -1021,7 +1021,7 @@ impl<R: Reader> Build<Model> for ModelBuilder<R> {
                 w: loader.load_vector_f16("blocks.0.ln0.weight")?,
                 b: loader.load_vector_f16("blocks.0.ln0.bias")?,
             },
-            w: loader.load_embed().await?,
+            w: loader.load_embed()?,
             u: match embed_device {
                 EmbedDevice::Cpu => None,
                 EmbedDevice::Gpu => Some(loader.load_matrix_f16("emb.weight")?),


### PR DESCRIPTION
The current loader uses a lot of 'await', but actually they are sync functions with the 'async' keyword. I guess those keywords are added for debugging purposes. But now they are useless and waste execution time and memory.
This PR remove those 'async' keyword to make the code simple.