### PR TITLE
Use `u32` for token id to avoid overflow issues

### DIFF
--- a/crates/web-rwkv-derive/src/serde/de.rs
+++ b/crates/web-rwkv-derive/src/serde/de.rs
@@ -2615,9 +2615,9 @@ impl ToTokens for DeTypeGenerics<'_> {
 fn split_with_de_lifetime(
     params: &Parameters,
 ) -> (
-    DeImplGenerics,
-    DeTypeGenerics,
-    syn::TypeGenerics,
+    DeImplGenerics<'_>,
+    DeTypeGenerics<'_>,
+    syn::TypeGenerics<'_>,
     Option<&syn::WhereClause>,
 ) {
     let de_impl_generics = DeImplGenerics(params);

--- a/crates/web-rwkv-derive/src/serde/internals/attr.rs
+++ b/crates/web-rwkv-derive/src/serde/internals/attr.rs
@@ -695,7 +695,7 @@ impl Container {
         self.serde_path.as_ref()
     }
 
-    pub fn serde_path(&self) -> Cow<syn::Path> {
+    pub fn serde_path(&self) -> Cow<'_, syn::Path> {
         self.custom_serde_path()
             .map_or_else(|| Cow::Owned(parse_quote!(_serde)), Cow::Borrowed)
     }

--- a/crates/web-rwkv-derive/src/serde/internals/case.rs
+++ b/crates/web-rwkv-derive/src/serde/internals/case.rs
@@ -42,7 +42,7 @@ static RENAME_RULES: &[(&str, RenameRule)] = &[
 ];
 
 impl RenameRule {
-    pub fn from_str(rename_all_str: &str) -> Result<Self, ParseError> {
+    pub fn from_str(rename_all_str: &str) -> Result<Self, ParseError<'_>> {
         for (name, rule) in RENAME_RULES {
             if rename_all_str == *name {
                 return Ok(*rule);

--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -38,13 +38,13 @@ use web_rwkv::{
     tokenizer::Tokenizer,
 };
 
-fn sample(probs: &[f32], _top_p: f32) -> u16 {
+fn sample(probs: &[f32], _top_p: f32) -> u32 {
     probs
         .iter()
         .enumerate()
         .max_by(|(_, x), (_, y)| x.total_cmp(y))
         .unwrap()
-        .0 as u16
+        .0 as u32
 }
 
 async fn create_context(info: &ModelInfo, _auto: bool) -> Result<Context> {

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -155,7 +155,7 @@ struct Sampler {
 }
 
 impl Sampler {
-    pub fn sample(&self, probs: &[f32]) -> u16 {
+    pub fn sample(&self, probs: &[f32]) -> u32 {
         let sorted: Vec<_> = probs
             .iter()
             .copied()
@@ -188,7 +188,7 @@ impl Sampler {
             .find_or_first(|&(_, cum)| rand <= cum)
             .map(|(id, _)| id)
             .unwrap_or_default();
-        token as u16
+        token as u32
     }
 }
 

--- a/examples/gen.rs
+++ b/examples/gen.rs
@@ -31,13 +31,13 @@ use web_rwkv::{
     tokenizer::Tokenizer,
 };
 
-fn sample(probs: &[f32], _top_p: f32) -> u16 {
+fn sample(probs: &[f32], _top_p: f32) -> u32 {
     probs
         .iter()
         .enumerate()
         .max_by(|(_, x), (_, y)| x.total_cmp(y))
         .unwrap()
-        .0 as u16
+        .0 as u32
 }
 
 async fn create_context(info: &ModelInfo, _auto: bool) -> Result<Context> {

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -31,13 +31,13 @@ use web_rwkv::{
     wgpu,
 };
 
-fn sample(probs: &[f32], _top_p: f32) -> u16 {
+fn sample(probs: &[f32], _top_p: f32) -> u32 {
     probs
         .iter()
         .enumerate()
         .max_by(|(_, x), (_, y)| x.total_cmp(y))
         .unwrap()
-        .0 as u16
+        .0 as u32
 }
 
 async fn create_context(info: &ModelInfo, _auto: bool) -> Result<Context> {

--- a/src/runtime/infer/mod.rs
+++ b/src/runtime/infer/mod.rs
@@ -20,7 +20,7 @@ pub trait Infer: Send + Sync + 'static {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Token {
-    Token(u16),
+    Token(u32),
     Embed(TensorCpu<f16>),
 }
 
@@ -30,8 +30,8 @@ impl Default for Token {
     }
 }
 
-impl From<u16> for Token {
-    fn from(value: u16) -> Self {
+impl From<u32> for Token {
+    fn from(value: u32) -> Self {
         Self::Token(value)
     }
 }

--- a/src/runtime/infer/rnn.rs
+++ b/src/runtime/infer/rnn.rs
@@ -363,10 +363,10 @@ mod tests {
     fn test_run_iter() -> Result<()> {
         let run = RnnInput {
             batches: [
-                (vec![0; 139], RnnOption::Last),
-                (vec![1; 1], RnnOption::Last),
-                (vec![2; 0], RnnOption::Full),
-                (vec![3; 65], RnnOption::Full),
+                (vec![0u32; 139], RnnOption::Last),
+                (vec![1u32; 1], RnnOption::Last),
+                (vec![2u32; 0], RnnOption::Full),
+                (vec![3u32; 65], RnnOption::Full),
             ]
             .map(|(tokens, option)| RnnInputBatch::new(tokens, option))
             .to_vec(),
@@ -447,10 +447,10 @@ mod tests {
     fn test_advance() -> Result<()> {
         let mut run = RnnInput {
             batches: [
-                (vec![0; 139], RnnOption::Last),
-                (vec![1; 1], RnnOption::Last),
-                (vec![2; 0], RnnOption::Full),
-                (vec![3; 65], RnnOption::Full),
+                (vec![0u32; 139], RnnOption::Last),
+                (vec![1u32; 1], RnnOption::Last),
+                (vec![2u32; 0], RnnOption::Full),
+                (vec![3u32; 65], RnnOption::Full),
             ]
             .map(|(tokens, option)| RnnInputBatch::new(tokens, option))
             .to_vec(),
@@ -475,10 +475,10 @@ mod tests {
         // simulate adding one token to batch 1 after advancing.
         let run = RnnInput {
             batches: [
-                (vec![0; 61], RnnOption::Last),
-                (vec![1; 1], RnnOption::Last),
-                (vec![2; 0], RnnOption::Full),
-                (vec![3; 3], RnnOption::Full),
+                (vec![0u32; 61], RnnOption::Last),
+                (vec![1u32; 1], RnnOption::Last),
+                (vec![2u32; 0], RnnOption::Full),
+                (vec![3u32; 3], RnnOption::Full),
             ]
             .map(|(tokens, option)| RnnInputBatch::new(tokens, option))
             .to_vec(),
@@ -505,10 +505,10 @@ mod tests {
     fn test_redirect() -> Result<()> {
         let run = RnnInput {
             batches: [
-                (vec![0; 61], RnnOption::Last),
-                (vec![1; 0], RnnOption::Last),
-                (vec![2; 0], RnnOption::Full),
-                (vec![3; 3], RnnOption::Full),
+                (vec![0u32; 61], RnnOption::Last),
+                (vec![1u32; 0], RnnOption::Last),
+                (vec![2u32; 0], RnnOption::Full),
+                (vec![3u32; 3], RnnOption::Full),
             ]
             .map(|(tokens, option)| RnnInputBatch::new(tokens, option))
             .to_vec(),
@@ -522,14 +522,14 @@ mod tests {
 
         let run = RnnInput {
             batches: [
-                (vec![0; 11], RnnOption::Last),
-                (vec![1; 8], RnnOption::Last),
-                (vec![2; 9], RnnOption::Last),
-                (vec![3; 4], RnnOption::Last),
-                (vec![0; 11], RnnOption::Last),
-                (vec![1; 8], RnnOption::Last),
-                (vec![2; 9], RnnOption::Last),
-                (vec![3; 4], RnnOption::Last),
+                (vec![0u32; 11], RnnOption::Last),
+                (vec![1u32; 8], RnnOption::Last),
+                (vec![2u32; 9], RnnOption::Last),
+                (vec![3u32; 4], RnnOption::Last),
+                (vec![0u32; 11], RnnOption::Last),
+                (vec![1u32; 8], RnnOption::Last),
+                (vec![2u32; 9], RnnOption::Last),
+                (vec![3u32; 4], RnnOption::Last),
             ]
             .map(|(tokens, option)| RnnInputBatch::new(tokens, option))
             .to_vec(),

--- a/src/runtime/loader.rs
+++ b/src/runtime/loader.rs
@@ -45,7 +45,7 @@ pub trait Reader {
     fn names(&self) -> Vec<&str>;
     fn contains(&self, name: &str) -> bool;
     fn shape(&self, name: &str) -> Result<Vec<usize>, SafeTensorError>;
-    fn tensor(&self, name: &str) -> Result<ReaderTensor, SafeTensorError>;
+    fn tensor(&self, name: &str) -> Result<ReaderTensor<'_>, SafeTensorError>;
 }
 
 impl Reader for SafeTensors<'_> {
@@ -65,7 +65,7 @@ impl Reader for SafeTensors<'_> {
     }
 
     #[inline]
-    fn tensor(&self, name: &str) -> Result<ReaderTensor, SafeTensorError> {
+    fn tensor(&self, name: &str) -> Result<ReaderTensor<'_>, SafeTensorError> {
         let tensor = SafeTensors::tensor(self, name)?;
         let shape = tensor.shape().to_vec();
         let data = tensor.data().into();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -265,7 +265,7 @@ impl<M, I, J> SimpleRuntime<M, I, J> {
 #[allow(clippy::type_complexity)]
 pub trait Runtime<I: infer::Infer> {
     #[cfg(not(target_arch = "wasm32"))]
-    fn infer(&self, input: I::Input) -> BoxFuture<Result<(I::Input, I::Output), RuntimeError>>;
+    fn infer(&self, input: I::Input) -> BoxFuture<'_, Result<(I::Input, I::Output), RuntimeError>>;
 
     #[cfg(target_arch = "wasm32")]
     fn infer(&self, input: I::Input)
@@ -282,7 +282,7 @@ where
     for<'a> &'a I::Input: IntoIterator<Item = T, IntoIter = F>,
 {
     #[cfg(not(target_arch = "wasm32"))]
-    fn infer(&self, input: I::Input) -> BoxFuture<Result<(I::Input, I::Output), RuntimeError>> {
+    fn infer(&self, input: I::Input) -> BoxFuture<'_, Result<(I::Input, I::Output), RuntimeError>> {
         Box::pin(self.infer(input))
     }
 }
@@ -298,7 +298,7 @@ where
     F: Iterator<Item = T> + Send + 'static,
     for<'a> &'a I::Input: IntoIterator<Item = T, IntoIter = F>,
 {
-    fn infer(&self, input: I::Input) -> BoxFuture<Result<(I::Input, I::Output), RuntimeError>> {
+    fn infer(&self, input: I::Input) -> BoxFuture<'_, Result<(I::Input, I::Output), RuntimeError>> {
         Box::pin(self.infer(input))
     }
 }

--- a/src/runtime/model.rs
+++ b/src/runtime/model.rs
@@ -83,14 +83,14 @@ pub trait State {
     /// Initialize a one-batch state on CPU.
     fn init(&self) -> TensorCpu<f32>;
     /// The part of the state that is used in an `att` layer.
-    fn att(&self, layer: usize) -> Result<TensorGpuView<f32>, TensorError>;
+    fn att(&self, layer: usize) -> Result<TensorGpuView<'_, f32>, TensorError>;
     /// The part of the state that is used in an `ffn` layer.
-    fn ffn(&self, layer: usize) -> Result<TensorGpuView<f32>, TensorError>;
+    fn ffn(&self, layer: usize) -> Result<TensorGpuView<'_, f32>, TensorError>;
     /// Load a batch of the state from CPU to GPU.
     fn load(&self, tensor: TensorCpu<f32>, batch: usize) -> Result<(), TensorError>;
     /// Read back a batch of the state from GPU to CPU.
     #[cfg(not(target_arch = "wasm32"))]
-    fn back(&self, batch: usize) -> BoxFuture<Result<TensorCpu<f32>, TensorError>>;
+    fn back(&self, batch: usize) -> BoxFuture<'_, Result<TensorCpu<f32>, TensorError>>;
     /// Read back a batch of the state from GPU to CPU.
     #[cfg(target_arch = "wasm32")]
     fn back(&self, batch: usize) -> LocalBoxFuture<Result<TensorCpu<f32>, TensorError>>;

--- a/src/runtime/v4.rs
+++ b/src/runtime/v4.rs
@@ -172,13 +172,13 @@ impl super::model::State for State {
         TensorCpu::from_data(self.init_shape(), data).unwrap()
     }
 
-    fn att(&self, layer: usize) -> Result<TensorGpuView<f32>, TensorError> {
+    fn att(&self, layer: usize) -> Result<TensorGpuView<'_, f32>, TensorError> {
         let start = 5 * layer;
         let end = start + 4;
         self.data.view(.., start..end, .., ..)
     }
 
-    fn ffn(&self, layer: usize) -> Result<TensorGpuView<f32>, TensorError> {
+    fn ffn(&self, layer: usize) -> Result<TensorGpuView<'_, f32>, TensorError> {
         let start = 5 * layer + 4;
         self.data.view(.., start..=start, .., ..)
     }
@@ -190,7 +190,7 @@ impl super::model::State for State {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn back(&self, batch: usize) -> BoxFuture<Result<TensorCpu<f32>, TensorError>> {
+    fn back(&self, batch: usize) -> BoxFuture<'_, Result<TensorCpu<f32>, TensorError>> {
         Box::pin(self.back(batch))
     }
 

--- a/src/runtime/v5.rs
+++ b/src/runtime/v5.rs
@@ -172,13 +172,13 @@ impl super::model::State for State {
         TensorCpu::from_data(shape, data).unwrap()
     }
 
-    fn att(&self, layer: usize) -> Result<TensorGpuView<f32>, TensorError> {
+    fn att(&self, layer: usize) -> Result<TensorGpuView<'_, f32>, TensorError> {
         let head_size = self.info.num_emb / self.info.num_head;
         let end = head_size + 1;
         self.data[layer].view(.., 0..end, .., ..)
     }
 
-    fn ffn(&self, layer: usize) -> Result<TensorGpuView<f32>, TensorError> {
+    fn ffn(&self, layer: usize) -> Result<TensorGpuView<'_, f32>, TensorError> {
         let head_size = self.info.num_emb / self.info.num_head;
         let start = head_size + 1;
         self.data[layer].view(.., start, .., ..)
@@ -194,7 +194,7 @@ impl super::model::State for State {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn back(&self, batch: usize) -> BoxFuture<Result<TensorCpu<f32>, TensorError>> {
+    fn back(&self, batch: usize) -> BoxFuture<'_, Result<TensorCpu<f32>, TensorError>> {
         Box::pin(self.back(batch))
     }
 

--- a/src/runtime/v6.rs
+++ b/src/runtime/v6.rs
@@ -184,13 +184,13 @@ impl super::model::State for State {
         TensorCpu::from_data(shape, data).unwrap()
     }
 
-    fn att(&self, layer: usize) -> Result<TensorGpuView<f32>, TensorError> {
+    fn att(&self, layer: usize) -> Result<TensorGpuView<'_, f32>, TensorError> {
         let head_size = self.info.num_emb / self.info.num_head;
         let end = head_size + 1;
         self.data[layer].view(.., 0..end, .., ..)
     }
 
-    fn ffn(&self, layer: usize) -> Result<TensorGpuView<f32>, TensorError> {
+    fn ffn(&self, layer: usize) -> Result<TensorGpuView<'_, f32>, TensorError> {
         let head_size = self.info.num_emb / self.info.num_head;
         let start = head_size + 1;
         self.data[layer].view(.., start, .., ..)
@@ -206,7 +206,7 @@ impl super::model::State for State {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn back(&self, batch: usize) -> BoxFuture<Result<TensorCpu<f32>, TensorError>> {
+    fn back(&self, batch: usize) -> BoxFuture<'_, Result<TensorCpu<f32>, TensorError>> {
         Box::pin(self.back(batch))
     }
 

--- a/src/runtime/v7.rs
+++ b/src/runtime/v7.rs
@@ -195,13 +195,13 @@ impl super::model::State for State {
         TensorCpu::from_data(shape, data).unwrap()
     }
 
-    fn att(&self, layer: usize) -> Result<TensorGpuView<f32>, TensorError> {
+    fn att(&self, layer: usize) -> Result<TensorGpuView<'_, f32>, TensorError> {
         let head_size = self.info.num_emb / self.info.num_head;
         let end = head_size + 1;
         self.data[layer].view(.., 0..end, .., ..)
     }
 
-    fn ffn(&self, layer: usize) -> Result<TensorGpuView<f32>, TensorError> {
+    fn ffn(&self, layer: usize) -> Result<TensorGpuView<'_, f32>, TensorError> {
         let head_size = self.info.num_emb / self.info.num_head;
         let start = head_size + 1;
         self.data[layer].view(.., start, .., ..)
@@ -217,7 +217,7 @@ impl super::model::State for State {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn back(&self, batch: usize) -> BoxFuture<Result<TensorCpu<f32>, TensorError>> {
+    fn back(&self, batch: usize) -> BoxFuture<'_, Result<TensorCpu<f32>, TensorError>> {
         Box::pin(self.back(batch))
     }
 

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -248,9 +248,9 @@ pub trait TensorResource {
     /// Retrieve the key identifying a resource.
     fn resource_key(&self) -> ResourceKey;
     /// Binding for metadata of the tensor (shape, stride, etc.).
-    fn meta_binding(&self) -> BindingResource;
+    fn meta_binding(&self) -> BindingResource<'_>;
     /// Binding for actual data of the tensor.
-    fn binding(&self) -> BindingResource;
+    fn binding(&self) -> BindingResource<'_>;
 }
 
 /// A tensor on either CPU or GPU.
@@ -581,7 +581,7 @@ impl<T: Scalar, K: Kind> TensorResource for TensorGpu<T, K> {
     }
 
     #[inline]
-    fn meta_binding(&self) -> BindingResource {
+    fn meta_binding(&self) -> BindingResource<'_> {
         BindingResource::Buffer(BufferBinding {
             buffer: &self.meta,
             offset: 0,
@@ -590,7 +590,7 @@ impl<T: Scalar, K: Kind> TensorResource for TensorGpu<T, K> {
     }
 
     #[inline]
-    fn binding(&self) -> BindingResource {
+    fn binding(&self) -> BindingResource<'_> {
         BindingResource::Buffer(BufferBinding {
             buffer: &self.buffer,
             offset: 0,
@@ -1082,7 +1082,7 @@ impl<T: Scalar> TensorResource for TensorGpuView<'_, T> {
     }
 
     #[inline]
-    fn meta_binding(&self) -> BindingResource {
+    fn meta_binding(&self) -> BindingResource<'_> {
         BindingResource::Buffer(BufferBinding {
             buffer: &self.meta,
             offset: 0,
@@ -1091,7 +1091,7 @@ impl<T: Scalar> TensorResource for TensorGpuView<'_, T> {
     }
 
     #[inline]
-    fn binding(&self) -> BindingResource {
+    fn binding(&self) -> BindingResource<'_> {
         self.tensor.binding()
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -11,13 +11,13 @@ pub enum TokenizerError {
     #[error("no matching token found")]
     NoMatchingTokenFound,
     #[error("out of range token: {0}")]
-    OutOfRangeToken(u16),
+    OutOfRangeToken(u32),
 }
 
 #[derive(Debug, Clone, Getters)]
 pub struct Tokenizer {
     first_bytes_to_lengths: Vec<Box<[u16]>>,
-    bytes_to_token_index: HashMap<Vec<u8>, u16>,
+    bytes_to_token_index: HashMap<Vec<u8>, u32>,
     token_index_to_bytes: Vec<Vec<u8>>,
 }
 
@@ -30,10 +30,10 @@ enum StrOrBytes {
 
 impl Tokenizer {
     pub fn new(vocab: &str) -> Result<Self, TokenizerError> {
-        let map: BTreeMap<u16, StrOrBytes> =
+        let map: BTreeMap<u32, StrOrBytes> =
             serde_json::from_str(vocab).map_err(TokenizerError::FailedToParseVocabulary)?;
 
-        let list: Vec<(Vec<u8>, u16)> = map
+        let list: Vec<(Vec<u8>, u32)> = map
             .into_iter()
             .map(|(token, pattern)| {
                 let pattern = match pattern {
@@ -55,7 +55,9 @@ impl Tokenizer {
         });
 
         let mut token_index_to_bytes = Vec::new();
-        token_index_to_bytes.resize_with(u16::MAX as usize, Vec::new);
+        // Find the max token index to determine the size of the vector.
+        let max_token_index = list.iter().map(|(_, index)| *index).max().unwrap_or(0) as usize;
+        token_index_to_bytes.resize_with(max_token_index + 1, Vec::new);
 
         let mut bytes_to_token_index = HashMap::new();
         for (token_bytes, token_index) in list {
@@ -89,13 +91,13 @@ impl Tokenizer {
         })
     }
 
-    pub fn encode(&self, input: &[u8]) -> Result<Vec<u16>, TokenizerError> {
+    pub fn encode(&self, input: &[u8]) -> Result<Vec<u32>, TokenizerError> {
         let mut output = Vec::new();
         self.encode_into(input, &mut output)?;
         Ok(output)
     }
 
-    pub fn decode(&self, tokens: &[u16]) -> Result<Vec<u8>, TokenizerError> {
+    pub fn decode(&self, tokens: &[u32]) -> Result<Vec<u8>, TokenizerError> {
         let mut output = Vec::with_capacity(tokens.len());
         self.decode_into(tokens, &mut output)?;
         Ok(output)
@@ -106,7 +108,7 @@ impl Tokenizer {
     pub fn encode_into(
         &self,
         mut input: &[u8],
-        output: &mut Vec<u16>,
+        output: &mut Vec<u32>,
     ) -> Result<(), TokenizerError> {
         'next_token: while !input.is_empty() {
             let lengths = if input.len() >= 2 {
@@ -135,7 +137,7 @@ impl Tokenizer {
         Ok(())
     }
 
-    pub fn decode_into(&self, tokens: &[u16], output: &mut Vec<u8>) -> Result<(), TokenizerError> {
+    pub fn decode_into(&self, tokens: &[u32], output: &mut Vec<u8>) -> Result<(), TokenizerError> {
         for &token in tokens {
             let bytes = self
                 .token_index_to_bytes
@@ -159,11 +161,11 @@ impl JsTokenizer {
         Ok(Self(Tokenizer::new(vocab)?))
     }
 
-    pub fn encode(&self, input: &[u8]) -> Result<Vec<u16>, JsError> {
+    pub fn encode(&self, input: &[u8]) -> Result<Vec<u32>, JsError> {
         Ok(self.0.encode(input)?)
     }
 
-    pub fn decode(&self, tokens: &[u16]) -> Result<Vec<u8>, JsError> {
+    pub fn decode(&self, tokens: &[u32]) -> Result<Vec<u8>, JsError> {
         Ok(self.0.decode(tokens)?)
     }
 }


### PR DESCRIPTION
A simplified version of #53 that only contains the u32 token_id modifications.