### PR TITLE
Handle unaligned mmap'd tensor data in safetensors loader

### DIFF
--- a/src/runtime/loader.rs
+++ b/src/runtime/loader.rs
@@ -85,7 +85,15 @@ impl<T: Scalar> TensorFromReader<T> for TensorCpu<T> {
         }
         let shape = Shape::from_slice_rev(&shape)?;
         match data {
-            Cow::Borrowed(data) => Self::from_data(shape, bytemuck::cast_slice(data)),
+            Cow::Borrowed(data) => {
+                match bytemuck::try_cast_slice(data) {
+                    Ok(data) => Self::from_data(shape, data),
+                    Err(_) => {
+                        let data = bytemuck::pod_collect_to_vec::<u8, T>(data);
+                        Self::from_data(shape, Cow::Owned(data))
+                    }
+                }
+            }
             Cow::Owned(data) => {
                 let data = bytemuck::cast_slice(&data);
                 let data = Cow::Owned(data.to_vec());


### PR DESCRIPTION
When loading tensors from mmap'd safetensors files (e.g. sharded models such as [manifestai/powercoder-3b](https://huggingface.co/manifestai/powercoder-3b)), the borrowed data slice may not be aligned to the target type's alignment requirement. This causes bytemuck::cast_slice to panic.

Use try_cast_slice instead, falling back to pod_collect_to_vec (which handles unaligned input by copying) when alignment doesn't match.

Note: Support for @m-a-n-i-f-e-s-t (Powercoder-3B, Brumby-14B-Base) has landed in https://github.com/audreyt/web-rwkv/tree/main and will be in a forthcoming PR.