### PR TITLE
Fix clippy useless_conversion warnings in runtime split loops

### DIFF
--- a/src/runtime/v5.rs
+++ b/src/runtime/v5.rs
@@ -187,7 +187,7 @@ impl super::model::State for State {
     fn load(&self, tensor: TensorCpu<f32>, batch: usize) -> Result<(), TensorError> {
         let head_size = self.info.num_emb / self.info.num_head;
         tensor.check_shape([self.info.num_emb, head_size + 2, self.info.num_layer, 1])?;
-        for (data, source) in self.data.iter().zip(tensor.split(2)?.into_iter()) {
+        for (data, source) in self.data.iter().zip(tensor.split(2)?) {
             data.load_batch(&source, batch)?;
         }
         Ok(())

--- a/src/runtime/v6.rs
+++ b/src/runtime/v6.rs
@@ -199,7 +199,7 @@ impl super::model::State for State {
     fn load(&self, tensor: TensorCpu<f32>, batch: usize) -> Result<(), TensorError> {
         let head_size = self.info.num_emb / self.info.num_head;
         tensor.check_shape([self.info.num_emb, head_size + 2, self.info.num_layer, 1])?;
-        for (data, source) in self.data.iter().zip(tensor.split(2)?.into_iter()) {
+        for (data, source) in self.data.iter().zip(tensor.split(2)?) {
             data.load_batch(&source, batch)?;
         }
         Ok(())

--- a/src/runtime/v7.rs
+++ b/src/runtime/v7.rs
@@ -210,7 +210,7 @@ impl super::model::State for State {
     fn load(&self, tensor: TensorCpu<f32>, batch: usize) -> Result<(), TensorError> {
         let head_size = self.info.num_emb / self.info.num_head;
         tensor.check_shape([self.info.num_emb, head_size + 2, self.info.num_layer, 1])?;
-        for (data, source) in self.data.iter().zip(tensor.split(2)?.into_iter()) {
+        for (data, source) in self.data.iter().zip(tensor.split(2)?) {
             data.load_batch(&source, batch)?;
         }
         Ok(())


### PR DESCRIPTION
Remove redundant `.into_iter()` calls in `.zip(...)` arguments flagged by clippy under -D warnings (zip already accepts any IntoIterator).