### PR TITLE
Allow raw-ish HF safetensors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,8 +8,11 @@
 *.frag text eol=lf
 *.vert text eol=lf
 *.wgsl text eol=lf
+*.bash text eol=lf
+*.sh text eol=lf
 # Declare files that will always have CRLF line endings on checkout.
 *.sln text eol=crlf
+*.cmd text eol=crlf
 # Denote all files that are truly binary and should not be modified.
 *.png binary
 *.jpg binary

--- a/src/runtime/loader.rs
+++ b/src/runtime/loader.rs
@@ -204,6 +204,49 @@ pub struct Loader<R> {
     pub lora: Vec<Lora<R>>,
 }
 
+/// The internal axis on which `num_emb` must sit for a canonical RWKV low-rank
+/// adapter matrix, or `None` if `name` is not such an adapter.
+///
+/// Down-projections carry `num_emb` on the inner axis (`0`), up-projections on
+/// the outer one (`1`). This covers both v7 adapters (`*.w1/.a1/.g1/.v1` and
+/// `*.w2/.a2/.g2/.v2`) and the v6 time-mix / time-decay adapters
+/// (`*.time_mix_w1` / `*.time_decay_w1` and their `_w2` counterparts). The v7
+/// match uses an exact `.wN` suffix so it does not also catch the v6 `_wN`
+/// tensors; those are matched explicitly by their full suffix instead.
+fn lora_num_emb_axis(name: &str) -> Option<usize> {
+    let ends_with_dot =
+        |suffixes: &[&str]| suffixes.iter().any(|s| name.ends_with(&format!(".{s}")));
+    if ends_with_dot(&["w1", "a1", "g1", "v1"])
+        || ["time_mix_w1", "time_decay_w1"]
+            .iter()
+            .any(|s| name.ends_with(s))
+    {
+        Some(0)
+    } else if ends_with_dot(&["w2", "a2", "g2", "v2"])
+        || ["time_mix_w2", "time_decay_w2"]
+            .iter()
+            .any(|s| name.ends_with(s))
+    {
+        Some(1)
+    } else {
+        None
+    }
+}
+
+/// Reorient an adapter matrix to web-rwkv's canonical `(out, in)` on-disk layout
+/// if it was stored transposed (raw HuggingFace). If `num_emb` isn't on the
+/// expected axis the checkpoint is raw HF and we transpose. Converted
+/// checkpoints, and any non-adapter tensor, are returned untouched.
+///
+/// For the 3D v6 `time_mix_w2` (`[5, …, …]`) only the inner two axes are
+/// swapped, which is exactly what the `convert_safetensors.py` transpose does.
+fn orient_lora_matrix(name: &str, tensor: TensorCpu<f16>, num_emb: usize) -> TensorCpu<f16> {
+    match lora_num_emb_axis(name) {
+        Some(axis) if tensor.shape()[axis] != num_emb => tensor.transpose(),
+        _ => tensor,
+    }
+}
+
 impl<R: Reader> Loader<R> {
     pub fn info(model: &R) -> Result<ModelInfo, LoaderError> {
         let num_layer = {
@@ -295,18 +338,43 @@ impl<R: Reader> Loader<R> {
 
         let custom = match version {
             ModelVersion::V6 => {
-                let time_mix = model.shape("blocks.0.att.time_mix_w1")?[0] / 5;
-                let time_decay = model.shape("blocks.0.att.time_decay_w1")?[0];
+                // Each down-projection's two axes are `num_emb` and the (smaller)
+                // low rank. The rank is whichever axis isn't `num_emb`, regardless
+                // of whether the checkpoint is converted (`(rank, num_emb)`) or raw
+                // HuggingFace (`(num_emb, rank)`); they never coincide in practice.
+                // `time_mix_w1` packs all five mixes, so its rank is `5 * time_mix`.
+                let rank = |name: &str| -> Result<usize, LoaderError> {
+                    let shape = model.shape(name)?;
+                    Ok(if shape[0] == num_emb {
+                        shape[1]
+                    } else {
+                        shape[0]
+                    })
+                };
+                let time_mix = rank("blocks.0.att.time_mix_w1")? / 5;
+                let time_decay = rank("blocks.0.att.time_decay_w1")?;
                 ModelCustomInfo::V6(super::v6::CustomInfo {
                     time_mix,
                     time_decay,
                 })
             }
             ModelVersion::V7 => {
-                let w = model.shape("blocks.0.att.w1")?[0];
-                let a = model.shape("blocks.0.att.a1")?[0];
-                let g = model.shape("blocks.0.att.g1")?[0];
-                let v = model.shape("blocks.1.att.v1")?[0];
+                // Each adapter's two axes are `num_emb` and the (smaller) low rank.
+                // The rank is whichever axis isn't `num_emb`, regardless of whether
+                // the checkpoint is converted (`(rank, num_emb)`) or raw HuggingFace
+                // (`(num_emb, rank)`). `rank == num_emb` never happens in practice.
+                let rank = |name: &str| -> Result<usize, LoaderError> {
+                    let shape = model.shape(name)?;
+                    Ok(if shape[0] == num_emb {
+                        shape[1]
+                    } else {
+                        shape[0]
+                    })
+                };
+                let w = rank("blocks.0.att.w1")?;
+                let a = rank("blocks.0.att.a1")?;
+                let g = rank("blocks.0.att.g1")?;
+                let v = rank("blocks.1.att.v1")?;
                 ModelCustomInfo::V7(super::v7::CustomInfo { w, a, g, v })
             }
             _ => ModelCustomInfo::None,
@@ -571,7 +639,14 @@ impl<R: Reader> Loader<R> {
     ) -> Result<TensorGpu<f16, ReadWrite>, LoaderError> {
         let context = &self.context;
         let tensor = self.model.tensor(name.as_ref())?;
-        let tensor: TensorGpu<_, _> = TensorCpu::from_reader(tensor)?.to(context);
+        let tensor = TensorCpu::from_reader(tensor)?;
+        let tensor = match lora_num_emb_axis(name.as_ref()) {
+            Some(_) => {
+                orient_lora_matrix(name.as_ref(), tensor, self.model.shape("emb.weight")?[1])
+            }
+            None => tensor,
+        };
+        let tensor: TensorGpu<_, _> = tensor.to(context);
 
         let mut ops = vec![];
         for lora in self.lora_matrices(name.as_ref())? {
@@ -759,5 +834,111 @@ impl<R: Reader> Loader<R> {
                 Ok(Matrix::quant_sf4(&buffer, 5.0)?)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use half::f16;
+
+    use super::{lora_num_emb_axis, orient_lora_matrix};
+    use crate::tensor::{shape::Shape, TensorCpu, TensorInit, TensorShape};
+
+    fn f16_tensor(shape: Shape, len: usize) -> TensorCpu<f16> {
+        let data: Vec<f16> = (0..len).map(|x| f16::from_f32(x as f32)).collect();
+        TensorCpu::from_data(shape, data).unwrap()
+    }
+
+    #[test]
+    fn test_lora_num_emb_axis() {
+        // down-projections carry `num_emb` on the inner axis (0): v7 `.wN` adapters
+        // and the v6 `time_mix_w1` / `time_decay_w1` time-mix adapters.
+        for name in [
+            "blocks.0.att.w1",
+            "blocks.3.att.a1",
+            "b.g1",
+            "b.v1",
+            "blocks.0.att.time_mix_w1",
+            "blocks.0.att.time_decay_w1",
+        ] {
+            assert_eq!(lora_num_emb_axis(name), Some(0), "{name}");
+        }
+        // up-projections on the outer axis (1): v7 `.wN` adapters and the v6
+        // `time_mix_w2` / `time_decay_w2` counterparts.
+        for name in [
+            "blocks.0.att.w2",
+            "blocks.3.att.a2",
+            "b.g2",
+            "b.v2",
+            "blocks.0.att.time_mix_w2",
+            "blocks.0.att.time_decay_w2",
+        ] {
+            assert_eq!(lora_num_emb_axis(name), Some(1), "{name}");
+        }
+        // not adapters: big linears, time-mix *vectors* (`time_mix_w`, not `_w1`),
+        // and v5 `time_state` (square, undetectable by shape).
+        for name in [
+            "blocks.0.att.key.weight",
+            "head.weight",
+            "blocks.0.att.time_mix_w",
+            "blocks.0.att.time_state",
+        ] {
+            assert_eq!(lora_num_emb_axis(name), None, "{name}");
+        }
+    }
+
+    /// A converted (canonical) adapter and its raw-HF transpose must both end up
+    /// in the same canonical `[in, out]` internal layout after orientation.
+    #[test]
+    fn test_orient_lora_both_orientations() {
+        const NUM_EMB: usize = 4;
+        const RANK: usize = 2;
+
+        // down-projection (`*.w1`): canonical internal shape is `[num_emb, rank]`.
+        let canonical = f16_tensor(Shape::new(NUM_EMB, RANK, 1, 1), NUM_EMB * RANK);
+        // converted checkpoint is already canonical -> untouched.
+        let converted = orient_lora_matrix("blocks.0.att.w1", canonical.clone(), NUM_EMB);
+        assert_eq!(converted.shape(), canonical.shape());
+        assert_eq!(converted.to_vec(), canonical.to_vec());
+        // raw HF is stored transposed -> orientation recovers the canonical tensor.
+        let raw = canonical.clone().transpose();
+        assert_eq!(raw.shape(), Shape::new(RANK, NUM_EMB, 1, 1));
+        let oriented = orient_lora_matrix("blocks.0.att.w1", raw, NUM_EMB);
+        assert_eq!(oriented.shape(), canonical.shape());
+        assert_eq!(oriented.to_vec(), canonical.to_vec());
+
+        // up-projection (`*.w2`): canonical internal shape is `[rank, num_emb]`.
+        let canonical = f16_tensor(Shape::new(RANK, NUM_EMB, 1, 1), NUM_EMB * RANK);
+        let converted = orient_lora_matrix("blocks.1.att.w2", canonical.clone(), NUM_EMB);
+        assert_eq!(converted.to_vec(), canonical.to_vec());
+        let raw = canonical.clone().transpose();
+        assert_eq!(raw.shape(), Shape::new(NUM_EMB, RANK, 1, 1));
+        let oriented = orient_lora_matrix("blocks.1.att.w2", raw, NUM_EMB);
+        assert_eq!(oriented.shape(), canonical.shape());
+        assert_eq!(oriented.to_vec(), canonical.to_vec());
+
+        // a non-adapter tensor is never transposed, even with a matching shape.
+        let key = f16_tensor(Shape::new(NUM_EMB, NUM_EMB, 1, 1), NUM_EMB * NUM_EMB);
+        let out = orient_lora_matrix("blocks.0.att.key.weight", key.clone(), NUM_EMB);
+        assert_eq!(out.to_vec(), key.to_vec());
+
+        // v6 `time_mix_w1` (down-projection) behaves like a `.w1`: canonical
+        // internal shape `[num_emb, 5 * rank]`.
+        let canonical = f16_tensor(Shape::new(NUM_EMB, 5 * RANK, 1, 1), NUM_EMB * 5 * RANK);
+        let raw = canonical.clone().transpose();
+        let oriented = orient_lora_matrix("blocks.0.att.time_mix_w1", raw, NUM_EMB);
+        assert_eq!(oriented.shape(), canonical.shape());
+        assert_eq!(oriented.to_vec(), canonical.to_vec());
+
+        // v6 `time_mix_w2` is 3D: canonical internal shape `[rank, num_emb, 5]`,
+        // with the outer `5` axis preserved through the inner-axis transpose.
+        let canonical = f16_tensor(Shape::new(RANK, NUM_EMB, 5, 1), RANK * NUM_EMB * 5);
+        let converted = orient_lora_matrix("blocks.0.att.time_mix_w2", canonical.clone(), NUM_EMB);
+        assert_eq!(converted.to_vec(), canonical.to_vec());
+        let raw = canonical.clone().transpose();
+        assert_eq!(raw.shape(), Shape::new(NUM_EMB, RANK, 5, 1));
+        let oriented = orient_lora_matrix("blocks.0.att.time_mix_w2", raw, NUM_EMB);
+        assert_eq!(oriented.shape(), canonical.shape());
+        assert_eq!(oriented.to_vec(), canonical.to_vec());
     }
 }

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -905,6 +905,23 @@ impl<T: Scalar> TensorCpu<T> {
         TensorInit::from_data(shape, data).unwrap()
     }
 
+    /// Transpose the inner two axes (`x` and `y`), preserving the outer two.
+    ///
+    /// For a 2D matrix held in web-rwkv's internal `[in, out]` layout this swaps
+    /// it to `[out, in]` (and back). It is how a raw HuggingFace low-rank adapter,
+    /// which is stored transposed relative to web-rwkv's canonical `(out, in)`
+    /// on-disk layout, is reoriented at load time.
+    pub fn transpose(self) -> Self {
+        let shape = Shape::new(self.shape[1], self.shape[0], self.shape[2], self.shape[3]);
+        let mut data = vec![T::zero(); shape.len()];
+        for index in self.shape.cartesian_product() {
+            let value = self[index];
+            let transposed = ShapedIndex::new(index[1], index[0], index[2], index[3]);
+            data[shape.linear_index(transposed)] = value;
+        }
+        TensorInit::from_data(shape, data).unwrap()
+    }
+
     /// Repeat the tensor along a given axis.
     pub fn repeat(self, axis: usize, repeat: usize) -> Self {
         let mut shape = self.shape;
@@ -1345,6 +1362,27 @@ mod tests {
         x[1].check_shape([5, 1, 1, 1])?;
         assert_eq!(x[0].to_vec(), vec![0.0, 1.0, 2.0, 3.0, 4.0]);
         assert_eq!(x[1].to_vec(), vec![5.0, 6.0, 7.0, 8.0, 9.0]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_transpose() -> Result<()> {
+        // Internal `[x = 3, y = 2]` (x is the fastest axis), i.e. the 2x3 matrix
+        // rows `[0, 1, 2]` and `[3, 4, 5]`.
+        let x = TensorCpu::from_data(
+            Shape::new(3, 2, 1, 1),
+            vec![0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0],
+        )?;
+
+        let t = x.clone().transpose();
+        t.check_shape([2, 3, 1, 1])?;
+        // element `(i, j)` moves to `(j, i)`.
+        assert_eq!(t.to_vec(), vec![0.0, 3.0, 1.0, 4.0, 2.0, 5.0]);
+
+        // transposing twice is the identity.
+        assert_eq!(x.clone().transpose().transpose().to_vec(), x.to_vec());
+        assert_eq!(x.clone().transpose().transpose().shape(), x.shape());
 
         Ok(())
     }


### PR DESCRIPTION
Basically, I'm allowing to load trasposed, HF-style tensors. Both orientations are still supported.